### PR TITLE
Fix the new `recommended` ruleset

### DIFF
--- a/recommended.js
+++ b/recommended.js
@@ -1,6 +1,6 @@
 module.exports = {
   extends: [
-    './index',
+    './index.js',
     'plugin:@typescript-eslint/recommended'
   ],
   


### PR DESCRIPTION
Otherwise it fails with the following errors:
```
Error: Cannot read config file: C:\myrepo\node_modules\@vue\eslint-config-typescript\index
Error: ENOENT: no such file or directory, open 'C:\myrepo\node_modules\@vue\eslint-config-typescript\index'
```