### PR TITLE
docs: Disambiguate

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ module.exports = {
   extends: [
     'plugin:vue/essential',
     'eslint:recommended',
-    '@vue/typescript'
+    '@vue/eslint-config-typescript'
   ]
 }
 ```
@@ -58,7 +58,7 @@ module.exports = {
   extends: [
     'plugin:vue/essential',
     '@vue/airbnb',
-    '@vue/typescript/recommended',
+    '@vue/eslint-config-typescript/recommended',
 
     '@vue/prettier',
     '@vue/prettier/@typescript-eslint'


### PR DESCRIPTION
Hi there,
According to #10 , @vue/eslint-config-typescript and @vue/typescript in README are equivalent since it has `eslint-config-` prefix. But I was wondering if `@vue/eslint-config-` 's `eslint-config-` regards as "prefix". Anyway, the examples should be described either one to avoid misunderstandings I suppose.

https://github.com/vuejs/eslint-config-typescript/tree/v7.0.0#readme

