### PR TITLE
Bump version eslint-plugin-vue in peerDep

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@typescript-eslint/eslint-plugin": "^5.0.0",
     "@typescript-eslint/parser": "^5.0.0",
     "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0",
-    "eslint-plugin-vue": "^7.17.0"
+    "eslint-plugin-vue": "^8.0.1"
   },
   "dependencies": {
     "vue-eslint-parser": "^8.0.0"


### PR DESCRIPTION
Fixes the mismatch between devDep & peerDep => "^8.0.1"