### PR TITLE
fix: add missing peer dependency `typescript`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,13 @@
   },
   "peerDependencies": {
     "eslint": "^6.2.0 || ^7.0.0 || ^8.0.0",
-    "eslint-plugin-vue": "^8.0.1"
+    "eslint-plugin-vue": "^8.0.1",
+    "typescript": "*"
+  },
+  "peerDependenciesMeta": {
+    "typescript": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@typescript-eslint/eslint-plugin": "^5.0.0",


### PR DESCRIPTION
**What's the problem this PR addresses?**

`@typescript-eslint/eslint-plugin` has an optional peer dependency on `typescript` that `@vue/eslint-config-typescript` doesn't provide.

**How did you fix it?**

Added `typescript` as an optional peer dependency.