### PR TITLE
fix: add parser option for cjs,mjs,cts,mts

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,9 +9,13 @@ module.exports = {
     parser: {
       'js': 'espree',
       'jsx': 'espree',
+      'cjs': 'espree',
+      'mjs': 'espree',
 
       'ts': require.resolve('@typescript-eslint/parser'),
       'tsx': require.resolve('@typescript-eslint/parser'),
+      'cts': require.resolve('@typescript-eslint/parser'),
+      'mts': require.resolve('@typescript-eslint/parser'),
 
       // Leave the template parser unspecified, so that it could be determined by `<script lang="...">`
     },
@@ -27,7 +31,7 @@ module.exports = {
 
   overrides: [
     {
-      files: ['*.ts', '*.tsx', '*.vue'],
+      files: ['*.ts', '*.mts', '*.tsx', '*.vue'],
       rules: {
         // The core 'no-unused-vars' rules (in the eslint:recommeded ruleset)
         // does not work with type definitions

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
 
   overrides: [
     {
-      files: ['*.ts', '*.mts', '*.tsx', '*.vue'],
+      files: ['*.ts', '*.cts', '*.mts', '*.tsx', '*.vue'],
       rules: {
         // The core 'no-unused-vars' rules (in the eslint:recommeded ruleset)
         // does not work with type definitions


### PR DESCRIPTION
I found ESLint will raise error in `.mts` file:

![image](https://user-images.githubusercontent.com/40021217/201292312-53298973-ad5f-47d1-812a-2d919c1d0b97.png)

