### PR TITLE
Add recommended-type-checked

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "files": [
     "index.js",
-    "recommended.js"
+    "recommended.js",
+    "recommended-type-checked.js"
   ],
   "scripts": {
     "test": "jest"

--- a/recommended-type-checked.js
+++ b/recommended-type-checked.js
@@ -1,0 +1,52 @@
+module.exports = {
+  extends: [
+    require.resolve('./index'),
+    'plugin:@typescript-eslint/recommended-type-checked'
+  ],
+  
+  // the ts-eslint recommended ruleset sets the parser so we need to set it back
+  parser: require.resolve('vue-eslint-parser'),
+
+  parserOptions: {
+    parser: require('typescript-eslint-parser-for-extra-files')
+  },
+
+  rules: {
+    // this rule, if on, would require explicit return type on the `render` function
+    '@typescript-eslint/explicit-function-return-type': 'off',
+
+    // The following rules are enabled in an `overrides` field in the
+    // `@typescript-eslint/recommended` ruleset, only turned on for TypeScript source modules
+    // <https://github.com/typescript-eslint/typescript-eslint/blob/cb2d44650d27d8b917e8ce19423245b834db29d2/packages/eslint-plugin/src/configs/eslint-recommended.ts#L27-L30>
+
+    // But as ESLint cannot precisely target `<script lang="ts">` blocks and skip normal `<script>`s,
+    // no TypeScript code in `.vue` files would be checked against these rules.
+    
+    // So we now enable them globally.
+    // That would also check plain JavaScript files, which diverges a little from
+    // the original intention of the `@typescript-eslint/recommended` rulset.
+    // But it should be mostly fine.
+    'no-var': 'error', // ts transpiles let/const to var, so no need for vars any more
+    'prefer-const': 'error', // ts provides better types with const
+    'prefer-rest-params': 'error', // ts provides better types with rest args over arguments
+    'prefer-spread': 'error', // ts transpiles spread to apply, so no need for manual apply
+  },
+
+  overrides: [
+    {
+      files: ['shims-tsx.d.ts'],
+      rules: {
+        '@typescript-eslint/no-empty-interface': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unused-vars': 'off'
+      }
+    },
+    {
+      files: ['*.js', '*.cjs'],
+      rules: {
+        // in plain CommonJS modules, you can't use `import foo = require('foo')` to pass this rule, so it has to be disabled
+        '@typescript-eslint/no-var-requires': 'off'
+      }
+    }
+  ]
+}


### PR DESCRIPTION
This can be used like this:
```js
// @ts-check
/* eslint-env node */
require('@rushstack/eslint-patch/modern-module-resolution');

/** @type {import('eslint').Linter.Config} */
module.exports = {
  root: true,
  extends: [
    'plugin:vue/vue3-recommended',
    'eslint:recommended',
    '@vue/eslint-config-typescript/recommended-type-checked',
    '@vue/eslint-config-prettier',
  ],
  parserOptions: {
    ecmaVersion: 'latest',
    tsconfigRootDir: __dirname,
    project: [
      './tsconfig.app.json',
      './tsconfig.vitest.json',
      './tsconfig.node.json',
      './e2e/tsconfig.json',
    ],
  },
};
```

And adding [`typescript-eslint-parser-for-extra-files`](https://github.com/ota-meshi/typescript-eslint-parser-for-extra-files) to `devDependencies`

See https://github.com/vuejs/vue-eslint-parser/issues/104 & https://github.com/vuejs/eslint-config-typescript/issues/29

cc @ota-meshi 