### PR TITLE
chore: update deps to support typescript-eslint v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@vue/eslint-config-typescript",
-  "version": "12.0.0",
+  "version": "13.0.0",
   "description": "eslint-config-typescript for vue-cli",
   "main": "index.js",
   "files": [
@@ -30,7 +30,7 @@
   },
   "homepage": "https://github.com/vuejs/eslint-config-typescript#readme",
   "devDependencies": {
-    "eslint": "^8.49.0",
+    "eslint": "^8.56.0",
     "eslint-plugin-vue": "^9.17.0",
     "execa": "^4.1.0",
     "jest": "^26.6.3",
@@ -50,11 +50,11 @@
     }
   },
   "dependencies": {
-    "@typescript-eslint/eslint-plugin": "^6.7.0",
-    "@typescript-eslint/parser": "^6.7.0",
+    "@typescript-eslint/eslint-plugin": "^7.0.0",
+    "@typescript-eslint/parser": "^7.0.0",
     "vue-eslint-parser": "^9.3.1"
   },
   "engines": {
-    "node": "^14.17.0 || >=16.0.0"
+    "node": "^18.18.0 || >=20.0.0"
   }
 }


### PR DESCRIPTION
Update dependencies to support typescript-eslint v7 (#69).

As this update leads to dropping support vor node-versions lower than 18 i opted to bump this packages major version, too.

Tested localy with node v20.8.1:

```
$ npm i
npm WARN deprecated source-map-url@0.4.1: See https://github.com/lydell/source-map-url#deprecated
npm WARN deprecated urix@0.1.0: Please see https://github.com/lydell/urix#deprecated
npm WARN deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm WARN deprecated source-map-resolve@0.5.3: See https://github.com/lydell/source-map-resolve#deprecated
npm WARN deprecated resolve-url@0.2.1: https://github.com/lydell/resolve-url#deprecated
npm WARN deprecated w3c-hr-time@1.0.2: Use your platform's native performance.now() and performance.timeOrigin.
npm WARN deprecated domexception@2.0.1: Use your platform's native DOMException instead
npm WARN deprecated sane@4.1.0: some dependency vulnerabilities fixed, support for node < 10 dropped, and newer ECMAScript syntax/features added
npm WARN deprecated vue@2.7.16: Vue 2 has reached EOL and is no longer actively maintained. See https://v2.vuejs.org/eol/ for more details.

added 613 packages, and audited 614 packages in 1m

found 0 vulnerabilities

$ npm test

> @vue/eslint-config-typescript@12.0.0 test
> jest

 PASS  test/index.spec.js (12.675 s)
  √ a default project should pass lint (2177 ms)
  √ should lint .ts file (2052 ms)
  √ should lint .vue file (2033 ms)
  √ should lint .tsx (1883 ms)
  √ should lint tsx block in .vue file (1892 ms)
  √ should not override eslint:recommended rules for normal js files (1870 ms)

Test Suites: 1 passed, 1 total
Tests:       6 passed, 6 total
Snapshots:   0 total
Time:        13.497 s
Ran all test suites.
```