### PR TITLE
fix: add missing dot to extraFileExtensions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,7 +92,7 @@ export default function createConfig({
           ecmaFeatures: {
             jsx: mayHaveJsxInSfc,
           },
-          extraFileExtensions: ['vue'],
+          extraFileExtensions: ['.vue'],
         },
       },
       rules: {


### PR DESCRIPTION
According this [this](https://typescript-eslint.io/packages/parser/#extrafileextensions) `extraFileExtensions` needs a `.` before the extension.

> Add extensions starting with `.`, followed by the file extension. E.g. for a `.vue` file use `"extraFileExtensions": [".vue"]`.