### PR TITLE
fix: skip typechecking cjs and mjs files

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -48,7 +48,7 @@ export default function createConfig({
   const projectServiceConfigs: ConfigArray = [
     {
       name: 'vue-typescript/skip-type-checking-for-js-files',
-      files: ['**/*.js', '**/*.jsx'],
+      files: ['**/*.js', '**/*.jsx', '**/*.cjs', '**/*.mjs'],
       ...tseslint.configs.disableTypeChecked,
     },
   ]


### PR DESCRIPTION
I have a `postcss.config.cjs` in my project, and when using the typechecked config recommended in the README, I ended up getting
```
Error: Error while loading rule '@typescript-eslint/await-thenable': You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file. See https://typescript-eslint.io/getting-started/typed-linting for enabling linting with type information.
Parser: typescript-eslint/parser
Occurred while linting /.../postcss.config.cjs
```
Such issues can be avoided by not just skipping .js files, but also .cjs and .mjs. Since .cjs and .mjs files are also Javascript files I believe this makes sense.