### PR TITLE
Add absolute path for reading file contents

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ export default function createConfig({
     .sync(['**/*.vue'], {
       cwd: rootDir,
       ignore: ['**/node_modules/**'],
+      absolute: true
     })
     .reduce(
       (acc, file) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import vueParser from 'vue-eslint-parser'
 import pluginVue from 'eslint-plugin-vue'
 
 import fg from 'fast-glob'
+import path from 'node:path'
 
 type ExtendableConfigName = keyof typeof tseslint.configs
 type ScriptLang = 'ts' | 'tsx' | 'js' | 'jsx'
@@ -30,11 +31,11 @@ export default function createConfig({
     .sync(['**/*.vue'], {
       cwd: rootDir,
       ignore: ['**/node_modules/**'],
-      absolute: true
     })
     .reduce(
       (acc, file) => {
-        const contents = fs.readFileSync(file, 'utf8')
+        const absolutePath = path.resolve(rootDir, file)
+        const contents = fs.readFileSync(absolutePath, 'utf8')
         // contents matches the <script lang="ts"> (there can be anything but `>` between `script` and `lang`)
         if (/<script[^>]*\blang\s*=\s*"ts"[^>]*>/i.test(contents)) {
           acc.vueFilesWithScriptTs.push(file)


### PR DESCRIPTION
The config generation breaks when specifiying a `rootDir` that is different than `.`. 

Example code that breaks:
```
import vueTsEslintConfig from '@vue/eslint-config-typescript';
vueTsEslintConfig({rootDir: 'src'}) 
```
Output:
```
node:fs:441
    return binding.readFileUtf8(path, stringToFlags(options.flag));
                   ^
Uncaught:
Error: ENOENT: no such file or directory, open 'components/Foo.vue'
    at Object.readFileSync (node:fs:441:20)
```

This PR changes the sync to use absolute paths. This way a different `rootDir` can be specified without breaking.