### PR TITLE
feat: add `includeDotFolders` option

### DIFF
--- a/src/groupVueFiles.ts
+++ b/src/groupVueFiles.ts
@@ -35,7 +35,7 @@ export default function groupVueFiles(
     .sync(['**/*.vue'], {
       cwd: rootDir,
       ignore,
-      dot: includeDotFolders
+      dot: includeDotFolders,
     })
     .reduce(
       (acc, file) => {

--- a/src/groupVueFiles.ts
+++ b/src/groupVueFiles.ts
@@ -13,6 +13,7 @@ type VueFilesByGroup = {
 export default function groupVueFiles(
   rootDir: string,
   globalIgnores: string[],
+  includeDotFolders?: boolean,
 ): VueFilesByGroup {
   debug(`Grouping .vue files in ${rootDir}`)
 
@@ -34,6 +35,7 @@ export default function groupVueFiles(
     .sync(['**/*.vue'], {
       cwd: rootDir,
       ignore,
+      dot: includeDotFolders
     })
     .reduce(
       (acc, file) => {

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -64,9 +64,9 @@ export type ProjectOptions = {
 
   /**
    * Allow patterns to match entries that begin with a period (.).
-   * Default is false.
+   * Default is `false`.
    */
-  includeDotFolders?: boolean;
+  includeDotFolders?: boolean
 
   /**
    * The root directory of the project.
@@ -99,7 +99,7 @@ export function configureVueProject(userOptions: ProjectOptions): void {
   if (userOptions.rootDir) {
     projectOptions.rootDir = userOptions.rootDir
   }
-  if(userOptions.includeDotFolders) {
+  if (userOptions.includeDotFolders) {
     projectOptions.includeDotFolders = userOptions.includeDotFolders
   }
 }
@@ -242,7 +242,11 @@ function insertAndReorderConfigs(configs: RawConfigItem[]): RawConfigItem[] {
     return configs
   }
 
-  const vueFiles = groupVueFiles(projectOptions.rootDir, globalIgnores, projectOptions.includeDotFolders)
+  const vueFiles = groupVueFiles(
+    projectOptions.rootDir,
+    globalIgnores,
+    projectOptions.includeDotFolders,
+  )
   const configsWithoutTypeAwareRules = configs.map(extractTypeAwareRules)
 
   const hasTypeAwareConfigs = configs.some(

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -63,6 +63,12 @@ export type ProjectOptions = {
   allowComponentTypeUnsafety?: boolean
 
   /**
+   * Allow patterns to match entries that begin with a period (.).
+   * Default is false.
+   */
+  includeDotFolders?: boolean;
+
+  /**
    * The root directory of the project.
    * Defaults to `process.cwd()`.
    */
@@ -73,6 +79,7 @@ let projectOptions = {
   tsSyntaxInTemplates: true as boolean,
   scriptLangs: ['ts'] as ScriptLang[],
   allowComponentTypeUnsafety: true as boolean,
+  includeDotFolders: false as boolean,
   rootDir: process.cwd(),
 } satisfies ProjectOptions
 
@@ -91,6 +98,9 @@ export function configureVueProject(userOptions: ProjectOptions): void {
   }
   if (userOptions.rootDir) {
     projectOptions.rootDir = userOptions.rootDir
+  }
+  if(userOptions.includeDotFolders) {
+    projectOptions.includeDotFolders = userOptions.includeDotFolders
   }
 }
 
@@ -232,7 +242,7 @@ function insertAndReorderConfigs(configs: RawConfigItem[]): RawConfigItem[] {
     return configs
   }
 
-  const vueFiles = groupVueFiles(projectOptions.rootDir, globalIgnores)
+  const vueFiles = groupVueFiles(projectOptions.rootDir, globalIgnores, projectOptions.includeDotFolders)
   const configsWithoutTypeAwareRules = configs.map(extractTypeAwareRules)
 
   const hasTypeAwareConfigs = configs.some(


### PR DESCRIPTION
When working with VitePress, I encountered an issue where the `.vitepress` folder wasn't included in the scan for Vue components because the leading dot defines it as a hidden folder. However, when I have components inside the `.vitepress` folder or any other dot leading folder and use type-aware lint rules (like the `recommendedTypeChecked` configuration), I get the following error: 
```
Error while loading rule '@typescript-eslint/await-thenable': You have used a rule which requires type information, but don't have parserOptions set to generate type information for this file. See https://tseslint.com/typed-linting for enabling linting with type information.
Parser: vue-eslint-parser
Note: detected a parser other than @typescript-eslint/parser. Make sure the parser is configured to forward "parserOptions.project" to @typescript-eslint/parser.
```

This could be solved by setting the `dot` option of the [fast-globe](https://www.npmjs.com/package/fast-glob#dot) in [groupVueFiles](https://github.com/vuejs/eslint-config-typescript/blob/main/src/groupVueFiles.ts#L33-L37) to `true`. 
Therefore I propose adding a new option `includeDotFolders` to the `configureVueProject` function which can be set to do exactly this.