### PR TITLE
chore(ci): set explicit least-privilege workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,10 @@ on:
   pull_request:
     branches:
       - '**'
+
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- add an explicit `permissions` block to CI workflow
- scope `GITHUB_TOKEN` to `contents: read`
- preserve existing test matrix and CI logic

## Why
Explicit least-privilege permissions reduce accidental over-scoping and make CI security posture easier to audit over time.