### PR TITLE
feat: make `vueTsConfigs` valid flat config objects and a new `withVueTs` helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,13 +25,113 @@ Please also make sure that you have `typescript` and `eslint` installed.
 
 ## Usage
 
-Because of the complexity of the configurations, this package exports several utilities:
+Starting in v14.9, `withVueTs` is the recommended way to compose this package with other flat configs. It returns a Promise, so you can export it directly from `eslint.config.js` / `eslint.config.mjs` / `eslint.config.ts`.
 
-- `defineConfigWithVueTs`, a utility function whose type signature is the same as the [`config` function from `typescript-eslint`](https://typescript-eslint.io/packages/typescript-eslint#config), but will modify the given ESLint config to work with Vue.js + TypeScript.
+The previous helpers remain available for backward compatibility and existing projects, but new setups should prefer `withVueTs`.
+
+This package exports:
+
+- `withVueTs`, a promise-driven utility for building a flat ESLint config that works with Vue.js + TypeScript. It accepts either `withVueTs(...configs)` or `withVueTs(options, ...configs)`, and also works with the result of `defineConfig()` from `eslint/config`.
 - `vueTsConfigs`, contains all the [shared configurations from `typescript-eslint`](https://typescript-eslint.io/users/configs) (in camelCase, e.g. `vueTsConfigs.recommendedTypeChecked`), and applies to `.vue` files in addition to TypeScript files.
-- a Vue-specific config factory: `configureVueProject(options)`. More info below.
+- `defineConfigWithVueTs`, the previous helper API. It is still supported, but new configs should prefer `withVueTs`.
+- `configureVueProject({ scriptLangs, rootDir, includeDotFolders, ... })`, the previous project-wide configuration API. In new configs, prefer passing the same options as the first argument to `withVueTs(...)`.
 
-### Minimal Setup
+### Recommended in v14.9+
+
+```js
+// eslint.config.mjs
+import pluginVue from 'eslint-plugin-vue'
+import { withVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+
+export default withVueTs(
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+)
+```
+
+The above configuration enables [the essential rules for Vue 3](https://eslint.vuejs.org/rules/#priority-a-essential-error-prevention) and [the recommended rules for TypeScript](https://typescript-eslint.io/rules/?=recommended).
+
+All the `<script>` blocks in `.vue` files _MUST_ be written in TypeScript (should be either `<script setup lang="ts">` or `<script lang="ts">`).
+
+If you need Vue-specific options such as `rootDir`, `includeDotFolders`, `scriptLangs`, `tsSyntaxInTemplates`, or `allowComponentTypeUnsafety`, pass them as the first argument:
+
+```js
+export default withVueTs(
+  {
+    rootDir: import.meta.dirname,
+    includeDotFolders: false,
+    scriptLangs: ['ts', 'js'],
+  },
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommendedTypeChecked,
+)
+```
+
+> [!NOTE]
+> If you prefer to compose with ESLint's built-in `defineConfig()` helper from `eslint/config`, that helper is available in ESLint 9.22.0 and later:
+>
+> ```js
+> import { defineConfig } from 'eslint/config'
+> import pluginVue from 'eslint-plugin-vue'
+> import { withVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+>
+> export default withVueTs(
+>   defineConfig(pluginVue.configs['flat/essential'], vueTsConfigs.recommended),
+> )
+> ```
+
+### Linting with Type Information
+
+Some `typescript-eslint` rules utilize type information to provide deeper insights into your code.
+But type-checking is a much slower process than linting with only syntax information.
+It is not always easy to set up the type-checking environment for ESLint without severe performance penalties.
+
+So we don't recommend you to configure individual type-aware rules and the corresponding language options all by yourself.
+Instead, you can start by extending from the `recommendedTypeChecked` configuration and then turn on/off the rules you need.
+
+```js
+// eslint.config.mjs
+import pluginVue from 'eslint-plugin-vue'
+import { withVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+
+export default withVueTs(
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommendedTypeChecked,
+)
+```
+
+### Previous APIs
+
+`defineConfigWithVueTs` and `configureVueProject` remain supported for existing setups. If you already use them, you do not need to migrate immediately. For new configs, prefer `withVueTs(...)`.
+
+Most uses of `configureVueProject(...)` can now be expressed by passing the same options as the first argument to `withVueTs(...)`.
+
+### Migration
+
+If you want to migrate an existing flat config from `defineConfigWithVueTs(...)` / `configureVueProject(...)` to `withVueTs(...)`, the primary migration interface is:
+
+```sh
+npx @vue/eslint-config-typescript migrate-to-with-vue-ts
+```
+
+This command is interactive by default. It discovers `eslint.config.{js,mjs,ts,mts}`, shows the planned changes, and asks before writing files.
+
+The codemod is intentionally conservative. It auto-fixes the common top-level helper patterns, and reports unusual cases such as non-top-level `configureVueProject(...)` calls or ambiguous first arguments for manual migration instead of guessing.
+
+You can also pass explicit paths or skip the prompt:
+
+```sh
+npx @vue/eslint-config-typescript migrate-to-with-vue-ts eslint.config.ts
+npx @vue/eslint-config-typescript migrate-to-with-vue-ts "packages/*/eslint.config.ts" --yes
+```
+
+There is also a versioned alias:
+
+```sh
+npx @vue/eslint-config-typescript migrate-14.9
+```
+
+But `migrate-to-with-vue-ts` should be treated as the primary interface. The alias is only a convenience for this specific migration and future releases may add other migrations.
 
 ```js
 // eslint.config.mjs
@@ -43,15 +143,29 @@ import {
 
 export default defineConfigWithVueTs(
   pluginVue.configs['flat/essential'],
-  vueTsConfigs.recommended,
+
+  // We STRONGLY RECOMMEND you to start with `recommended` or `recommendedTypeChecked`.
+  // But if you are determined to configure all rules by yourself,
+  // you can start with `base`, and then turn on/off the rules you need.
+  vueTsConfigs.base,
 )
 ```
 
-The above configuration enables [the essential rules for Vue 3](https://eslint.vuejs.org/rules/#priority-a-essential-error-prevention) and [the recommended rules for TypeScript](https://typescript-eslint.io/rules/?=recommended).
+You can still configure the project globally when you need to keep the previous API shape:
 
-All the `<script>` blocks in `.vue` files *MUST* be written in TypeScript (should be either `<script setup lang="ts">` or `<script lang="ts">`).
+```js
+import { configureVueProject } from '@vue/eslint-config-typescript'
 
-### Advanced Setup
+configureVueProject({
+  tsSyntaxInTemplates: true,
+  scriptLangs: ['ts', 'js'],
+  allowComponentTypeUnsafety: true,
+  rootDir: import.meta.dirname,
+  includeDotFolders: false,
+})
+```
+
+### Detailed Legacy Example
 
 ```js
 // eslint.config.mjs
@@ -120,41 +234,14 @@ configureVueProject({
 })
 
 export default defineConfigWithVueTs(
-  pluginVue.configs["flat/essential"],
-
-  // We STRONGLY RECOMMEND you to start with `recommended` or `recommendedTypeChecked`.
-  // But if you are determined to configure all rules by yourself,
-  // you can start with `base`, and then turn on/off the rules you need.
-  vueTsConfigs.base,
-)
-```
-
-### Linting with Type Information
-
-Some `typescript-eslint` rules utilizes type information to provide deeper insights into your code.
-But type-checking is a much slower process than linting with only syntax information.
-It is not always easy to set up the type-checking environment for ESLint without severe performance penalties.
-
-So we don't recommend you to configure individual type-aware rules and the corresponding language options all by yourself.
-Instead, you can start by extending from the `recommendedTypeChecked` configuration and then turn on/off the rules you need.
-
-```js
-// eslint.config.mjs
-import pluginVue from 'eslint-plugin-vue'
-import {
-  defineConfigWithVueTs,
-  vueTsConfigs,
-} from '@vue/eslint-config-typescript'
-
-export default defineConfigWithVueTs(
   pluginVue.configs['flat/essential'],
-  vueTsConfigs.recommendedTypeChecked
+  vueTsConfigs.recommendedTypeChecked,
 )
 ```
 
 ## Use As a Normal Shared ESLint Config (Not Recommended)
 
-You can use this package as a normal ESLint config, without the `defineConfigWithVueTs` helper. But in this case, overriding the rules for `.vue` files would be more difficult and comes with many nuances. Please be cautious.
+You can use this package as a normal ESLint config, without `withVueTs` or `defineConfigWithVueTs`. But in this case, overriding the rules for `.vue` files would be more difficult and comes with many nuances. Please be cautious.
 
 You can check [the documentation for 14.1 and earlier versions](https://github.com/vuejs/eslint-config-typescript/tree/v14.1.4#usage) for more information.
 

--- a/README.md
+++ b/README.md
@@ -4,16 +4,14 @@ ESLint configuration for Vue 3 + TypeScript projects.
 
 See [@typescript-eslint/eslint-plugin](https://typescript-eslint.io/rules/) for available rules.
 
-This config is specifically designed to be used by `create-vue` setups
-and is not meant for outside use (it can be used but some adaptations
-on the user side might be needed - for details see the config file).
+This config is designed for `create-vue` setups.
+Other projects can use it, but may need project-specific adjustments.
 
-A part of its design is that this config may implicitly depend on
-other parts of `create-vue` setups, such as `eslint-plugin-vue` being
-extended in the same resulting config.
+It may rely on other `create-vue` defaults, such as `eslint-plugin-vue`
+being extended in the same final config.
 
 > [!NOTE]
-> The current version doesn't support the legacy `.eslintrc*` configuration format. For that you need to use version 13 or earlier. See the [corresponding README](https://www.npmjs.com/package/@vue/eslint-config-typescript/v/legacy-eslintrc) for more usage instructions.
+> The current version doesn't support the legacy `.eslintrc*` configuration format. Use version 13 or earlier for that format. See the [corresponding README](https://www.npmjs.com/package/@vue/eslint-config-typescript/v/legacy-eslintrc) for more usage instructions.
 
 ## Installation
 
@@ -25,18 +23,16 @@ Please also make sure that you have `typescript` and `eslint` installed.
 
 ## Usage
 
-Starting in v14.9, `withVueTs` is the recommended way to compose this package with other flat configs. It returns a Promise, so you can export it directly from `eslint.config.js` / `eslint.config.mjs` / `eslint.config.ts`.
+For new flat configs, use these two exports:
 
-The previous helpers remain available for backward compatibility and existing projects, but new setups should prefer `withVueTs`.
+- `withVueTs`, a helper that builds a flat ESLint config for Vue.js + TypeScript. It accepts either `withVueTs(...configs)` or `withVueTs(options, ...configs)`.
+- `vueTsConfigs`, the [shared configurations from `typescript-eslint`](https://typescript-eslint.io/users/configs) adapted for `.vue` files in addition to TypeScript files. The names are in camel case, such as `vueTsConfigs.recommendedTypeChecked`.
 
-This package exports:
+The helper APIs used before v14.9 remain available for existing projects. See [Helper APIs Before v14.9](#helper-apis-before-v149).
 
-- `withVueTs`, a promise-driven utility for building a flat ESLint config that works with Vue.js + TypeScript. It accepts either `withVueTs(...configs)` or `withVueTs(options, ...configs)`, and also works with the result of `defineConfig()` from `eslint/config`.
-- `vueTsConfigs`, contains all the [shared configurations from `typescript-eslint`](https://typescript-eslint.io/users/configs) (in camelCase, e.g. `vueTsConfigs.recommendedTypeChecked`), and applies to `.vue` files in addition to TypeScript files.
-- `defineConfigWithVueTs`, the previous helper API. It is still supported, but new configs should prefer `withVueTs`.
-- `configureVueProject({ scriptLangs, rootDir, includeDotFolders, ... })`, the previous project-wide configuration API. In new configs, prefer passing the same options as the first argument to `withVueTs(...)`.
+### Recommended
 
-### Recommended in v14.9+
+`withVueTs(...)` is available in v14.9 and later. Export the `withVueTs(...)` call from `eslint.config.js`, `eslint.config.mjs`, or `eslint.config.ts`.
 
 ```js
 // eslint.config.mjs
@@ -53,41 +49,16 @@ The above configuration enables [the essential rules for Vue 3](https://eslint.v
 
 All the `<script>` blocks in `.vue` files _MUST_ be written in TypeScript (should be either `<script setup lang="ts">` or `<script lang="ts">`).
 
-If you need Vue-specific options such as `rootDir`, `includeDotFolders`, `scriptLangs`, `tsSyntaxInTemplates`, or `allowComponentTypeUnsafety`, pass them as the first argument:
-
-```js
-export default withVueTs(
-  {
-    rootDir: import.meta.dirname,
-    includeDotFolders: false,
-    scriptLangs: ['ts', 'js'],
-  },
-  pluginVue.configs['flat/essential'],
-  vueTsConfigs.recommendedTypeChecked,
-)
-```
-
-> [!NOTE]
-> If you prefer to compose with ESLint's built-in `defineConfig()` helper from `eslint/config`, that helper is available in ESLint 9.22.0 and later:
->
-> ```js
-> import { defineConfig } from 'eslint/config'
-> import pluginVue from 'eslint-plugin-vue'
-> import { withVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
->
-> export default withVueTs(
->   defineConfig(pluginVue.configs['flat/essential'], vueTsConfigs.recommended),
-> )
-> ```
+`withVueTs(...)` accepts config objects, config arrays, and promises. This matches the input style used by [`eslint-flat-config-utils`](https://github.com/antfu/eslint-flat-config-utils), so configs built with Antfu's or Nuxt's ESLint config utilities can be passed to `withVueTs(...)` for Vue + TypeScript resolution.
 
 ### Linting with Type Information
 
-Some `typescript-eslint` rules utilize type information to provide deeper insights into your code.
-But type-checking is a much slower process than linting with only syntax information.
-It is not always easy to set up the type-checking environment for ESLint without severe performance penalties.
+Some `typescript-eslint` rules use type information to provide deeper insights into the project code.
+Type-checking is much slower than linting with syntax information only.
+Setting up typed linting for ESLint without severe performance penalties can be difficult.
 
-So we don't recommend you to configure individual type-aware rules and the corresponding language options all by yourself.
-Instead, you can start by extending from the `recommendedTypeChecked` configuration and then turn on/off the rules you need.
+We don't recommend configuring individual type-aware rules and the corresponding language options manually.
+Start with the `recommendedTypeChecked` configuration, then turn rules on or off as needed.
 
 ```js
 // eslint.config.mjs
@@ -100,15 +71,120 @@ export default withVueTs(
 )
 ```
 
-### Previous APIs
+### Project Options
 
-`defineConfigWithVueTs` and `configureVueProject` remain supported for existing setups. If you already use them, you do not need to migrate immediately. For new configs, prefer `withVueTs(...)`.
+`withVueTs(...)` accepts options for this config as the first argument. These are the same options accepted by `configureVueProject(...)` in the helper APIs before v14.9.
 
-Most uses of `configureVueProject(...)` can now be expressed by passing the same options as the first argument to `withVueTs(...)`.
+Only pass the options that differ from the defaults. This example lists all available options:
+
+```js
+// eslint.config.mjs
+import pluginVue from 'eslint-plugin-vue'
+import { withVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+
+export default withVueTs(
+  {
+    // Whether to parse TypeScript syntax in Vue templates.
+    // Defaults to `true`.
+    // Setting it to `false` could improve performance.
+    // But TypeScript syntax in Vue templates will then lead to syntax errors.
+    // Also, type-aware rules won't be applied to expressions in templates in that case.
+    tsSyntaxInTemplates: true,
+
+    // Specify the script langs in `.vue` files
+    // Defaults to `['ts']`.
+    scriptLangs: [
+      'ts',
+
+      // [!DISCOURAGED]
+      // Include 'js' to allow plain `<script>` or `<script setup>` blocks.
+      // This might result-in false positive or negatives in some rules for `.vue` files.
+      // Note you also need to configure `allowJs: true` and `checkJs: true`
+      // in corresponding `tsconfig.json` files.
+      // 'js',
+
+      // [!STRONGLY DISCOURAGED]
+      // Include 'tsx' to allow `<script lang="tsx">` blocks.
+      // This would be in conflict with all type-aware rules.
+      // 'tsx',
+
+      // [!STRONGLY DISCOURAGED]
+      // Include 'jsx' to allow `<script lang="jsx">` blocks.
+      // This would be in conflict with all type-aware rules and may result in false positives.
+      // 'jsx',
+    ],
+
+    // Whether to override some `no-unsafe-*` rules to avoid false positives on Vue component operations.
+    // Defaults to `true`.
+    // Usually you should keep this enabled,
+    // but if you're using a metaframework or in a TSX-only project
+    // where you're certain you won't operate on `.vue` components in a way that violates the rules,
+    // and you want the strictest rules (e.g. when extending from `strictTypeChecked`),
+    // you can set this to `false` to ensure the strictest rules apply to all files.
+    allowComponentTypeUnsafety: true,
+
+    // The root directory to resolve the `.vue` files.
+    // Defaults to `process.cwd()`.
+    // More info: <https://github.com/vuejs/eslint-plugin-vue/issues/1910#issuecomment-1819993961>
+    // You may need to set this to the root directory of your project if you have a monorepo.
+    // This is useful when you allow any other languages than `ts` in `.vue` files.
+    // Our config helper would resolve and parse all the `.vue` files under `rootDir`,
+    // and only apply the loosened rules to the files that do need them.
+    rootDir: import.meta.dirname,
+
+    // Whether to include dot folders when resolving `.vue` files under `rootDir`.
+    // Defaults to `false`.
+    // You may need to set this to `true` if your project stores Vue components
+    // under folders such as `.vitepress`.
+    includeDotFolders: false,
+  },
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommendedTypeChecked,
+)
+```
+
+### Helper APIs Before v14.9
+
+Configs written before v14.9 usually use `defineConfigWithVueTs(...)` as the final config helper, with `configureVueProject(...)` for the same project options.
+
+Both APIs remain supported. `defineConfigWithVueTs(...)` accepts flat config entries and applies the final Vue + TypeScript resolution. `configureVueProject(...)` sets the project options used by `defineConfigWithVueTs(...)`.
+
+The pre-v14.9 API shape:
+
+```js
+configureVueProject(options)
+export default defineConfigWithVueTs(...configs)
+```
+
+maps to:
+
+```js
+export default withVueTs(options, ...configs)
+```
+
+```js
+// eslint.config.mjs
+import pluginVue from 'eslint-plugin-vue'
+import {
+  defineConfigWithVueTs,
+  vueTsConfigs,
+  configureVueProject,
+} from '@vue/eslint-config-typescript'
+
+configureVueProject({
+  rootDir: import.meta.dirname,
+  scriptLangs: ['ts', 'js'],
+})
+
+export default defineConfigWithVueTs(
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+)
+```
 
 ### Migration
 
-If you want to migrate an existing flat config from `defineConfigWithVueTs(...)` / `configureVueProject(...)` to `withVueTs(...)`, the primary migration interface is:
+To migrate an existing flat config from `defineConfigWithVueTs(...)` / `configureVueProject(...)` to `withVueTs(...)`, use:
 
 ```sh
 npx @vue/eslint-config-typescript migrate-to-with-vue-ts
@@ -116,9 +192,9 @@ npx @vue/eslint-config-typescript migrate-to-with-vue-ts
 
 This command is interactive by default. It discovers `eslint.config.{js,mjs,ts,mts}`, shows the planned changes, and asks before writing files.
 
-The codemod is intentionally conservative. It auto-fixes the common top-level helper patterns, and reports unusual cases such as non-top-level `configureVueProject(...)` calls or ambiguous first arguments for manual migration instead of guessing.
+The codemod is conservative. It auto-fixes common top-level helper patterns, and reports unusual cases such as non-top-level `configureVueProject(...)` calls or ambiguous first arguments for manual migration.
 
-You can also pass explicit paths or skip the prompt:
+Explicit paths and non-interactive runs are also supported:
 
 ```sh
 npx @vue/eslint-config-typescript migrate-to-with-vue-ts eslint.config.ts
@@ -131,126 +207,15 @@ There is also a versioned alias:
 npx @vue/eslint-config-typescript migrate-14.9
 ```
 
-But `migrate-to-with-vue-ts` should be treated as the primary interface. The alias is only a convenience for this specific migration and future releases may add other migrations.
-
-```js
-// eslint.config.mjs
-import pluginVue from 'eslint-plugin-vue'
-import {
-  defineConfigWithVueTs,
-  vueTsConfigs,
-} from '@vue/eslint-config-typescript'
-
-export default defineConfigWithVueTs(
-  pluginVue.configs['flat/essential'],
-
-  // We STRONGLY RECOMMEND you to start with `recommended` or `recommendedTypeChecked`.
-  // But if you are determined to configure all rules by yourself,
-  // you can start with `base`, and then turn on/off the rules you need.
-  vueTsConfigs.base,
-)
-```
-
-You can still configure the project globally when you need to keep the previous API shape:
-
-```js
-import { configureVueProject } from '@vue/eslint-config-typescript'
-
-configureVueProject({
-  tsSyntaxInTemplates: true,
-  scriptLangs: ['ts', 'js'],
-  allowComponentTypeUnsafety: true,
-  rootDir: import.meta.dirname,
-  includeDotFolders: false,
-})
-```
-
-### Detailed Legacy Example
-
-```js
-// eslint.config.mjs
-import pluginVue from 'eslint-plugin-vue'
-import {
-  defineConfigWithVueTs,
-  vueTsConfigs,
-  configureVueProject,
-} from '@vue/eslint-config-typescript'
-
-// Optional: configure the Vue project to adjust the strictness of the rulesets or speed up linting.
-configureVueProject({
-  // Whether to parse TypeScript syntax in Vue templates.
-  // Defaults to `true`.
-  // Setting it to `false` could improve performance.
-  // But TypeScript syntax in Vue templates will then lead to syntax errors.
-  // Also, type-aware rules won't be applied to expressions in templates in that case.
-  tsSyntaxInTemplates: true,
-
-  // Specify the script langs in `.vue` files
-  // Defaults to `['ts']`.
-  scriptLangs: [
-    'ts',
-
-    // [!DISCOURAGED]
-    // Include 'js' to allow plain `<script>` or `<script setup>` blocks.
-    // This might result-in false positive or negatives in some rules for `.vue` files.
-    // Note you also need to configure `allowJs: true` and `checkJs: true`
-    // in corresponding `tsconfig.json` files.
-    'js',
-
-    // [!STRONGLY DISCOURAGED]
-    // Include 'tsx' to allow `<script lang="tsx">` blocks.
-    // This would be in conflict with all type-aware rules.
-    'tsx',
-
-    // [!STRONGLY DISCOURAGED]
-    // Include 'jsx' to allow `<script lang="jsx">` blocks.
-    // This would be in conflict with all type-aware rules and may result in false positives.
-    'jsx',
-  ],
-
-  // Whether to override some `no-unsafe-*` rules to avoid false positives on Vue component operations.
-  // Defaults to `true`.
-  // Usually you should keep this enabled,
-  // but if you're using a metaframework or in a TSX-only project
-  // where you're certain you won't operate on `.vue` components in a way that violates the rules,
-  // and you want the strictest rules (e.g. when extending from `strictTypeChecked`),
-  // you can set this to `false` to ensure the strictest rules apply to all files.
-  allowComponentTypeUnsafety: true,
-
-  // The root directory to resolve the `.vue` files.
-  // Defaults to `process.cwd()`.
-  // More info: <https://github.com/vuejs/eslint-plugin-vue/issues/1910#issuecomment-1819993961>
-  // You may need to set this to the root directory of your project if you have a monorepo.
-  // This is useful when you allow any other languages than `ts` in `.vue` files.
-  // Our config helper would resolve and parse all the `.vue` files under `rootDir`,
-  // and only apply the loosened rules to the files that do need them.
-  rootDir: import.meta.dirname,
-
-  // Whether to include dot folders when resolving `.vue` files under `rootDir`.
-  // Defaults to `false`.
-  // You may need to set this to `true` if your project stores Vue components
-  // under folders such as `.vitepress`.
-  includeDotFolders: false,
-})
-
-export default defineConfigWithVueTs(
-  pluginVue.configs['flat/essential'],
-  vueTsConfigs.recommendedTypeChecked,
-)
-```
+Use `migrate-to-with-vue-ts` as the primary interface. The alias is only a convenience for this specific migration and future releases may add other migrations.
 
 ## Use As a Normal Shared ESLint Config (Not Recommended)
 
-You can use this package as a normal ESLint config, without `withVueTs` or `defineConfigWithVueTs`. But in this case, overriding the rules for `.vue` files would be more difficult and comes with many nuances. Please be cautious.
+This package can be used as a normal ESLint config, without `withVueTs` or `defineConfigWithVueTs`. In that setup, overriding the rules for `.vue` files is more difficult and comes with many nuances. Use this mode with caution.
 
-You can check [the documentation for 14.1 and earlier versions](https://github.com/vuejs/eslint-config-typescript/tree/v14.1.4#usage) for more information.
+See [the documentation for 14.1 and earlier versions](https://github.com/vuejs/eslint-config-typescript/tree/v14.1.4#usage) for more information.
 
 ## Further Reading
 
 - [All the extendable configurations from `typescript-eslint`](https://typescript-eslint.io/users/configs).
 - [All the available rules from `typescript-eslint`](https://typescript-eslint.io/rules/).
-
-### With Other Community Configs
-
-- For [JavaScript Standard Style](https://standardjs.com/), use [`@vue/eslint-config-standard-with-typescript`](https://github.com/vuejs/eslint-config-standard/tree/main/packages/eslint-config-standard-with-typescript#usage)
-- Airbnb JavaScript Style Guide support is still in progress.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
       "default": "./dist/index.mjs"
     }
   },
+  "bin": {
+    "vue-eslint-config-typescript": "./dist/bin.js"
+  },
   "scripts": {
     "dev": "pkgroll --watch",
     "build": "pkgroll",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^8.60.0
-        version: 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
       typescript-eslint:
         specifier: ^8.60.0
-        version: 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+        version: 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       vue-eslint-parser:
         specifier: ^10.4.0
-        version: 10.4.1(eslint@10.4.1(jiti@2.7.0))
+        version: 10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
     devDependencies:
       '@tsconfig/node24':
         specifier: ^24.0.4
@@ -29,10 +29,10 @@ importers:
         version: 22.19.21
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
       execa:
         specifier: ^9.6.1
         version: 9.6.1
@@ -160,7 +160,7 @@ importers:
         version: 3.8.3
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11
+        version: 3.0.11(supports-color@8.1.1)
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -328,7 +328,7 @@ importers:
         version: 3.8.3
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11
+        version: 3.0.11(supports-color@8.1.1)
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -505,7 +505,7 @@ importers:
         version: 3.8.3
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11
+        version: 3.0.11(supports-color@8.1.1)
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -560,7 +560,7 @@ importers:
         version: 9.0.1
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11
+        version: 3.0.11(supports-color@8.1.1)
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -1075,7 +1075,7 @@ importers:
     dependencies:
       vue:
         specifier: ^3.5.35
-        version: 3.5.35(typescript@6.0.3)
+        version: 3.5.38(typescript@6.0.3)
     devDependencies:
       '@vue/eslint-config-typescript':
         specifier: workspace:*
@@ -1085,7 +1085,7 @@ importers:
         version: 10.4.1(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -6286,6 +6286,11 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))':
+    dependencies:
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-visitor-keys: 3.4.3
+
   '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0))':
     dependencies:
       eslint: 10.4.1(jiti@2.7.0)
@@ -6293,7 +6298,7 @@ snapshots:
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5':
+  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@8.1.1)
@@ -7068,6 +7073,22 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
+  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.2
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/type-utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      ignore: 7.0.5
+      natural-compare: 1.4.0
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -7083,6 +7104,19 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
+
+  '@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.0
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
 
   '@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
@@ -7095,6 +7129,7 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@typescript-eslint/project-service@8.61.0(typescript@6.0.3)':
     dependencies:
@@ -7114,6 +7149,18 @@ snapshots:
     dependencies:
       typescript: 6.0.3
 
+  '@typescript-eslint/type-utils@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+    dependencies:
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/type-utils@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@typescript-eslint/types': 8.61.0
@@ -7125,6 +7172,7 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+    optional: true
 
   '@typescript-eslint/types@8.61.0': {}
 
@@ -7139,6 +7187,17 @@ snapshots:
       semver: 7.8.4
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))
+      '@typescript-eslint/scope-manager': 8.61.0
+      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -7463,7 +7522,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2:
+  agent-base@6.0.2(supports-color@8.1.1):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -7570,11 +7629,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.17.0(debug@4.4.3):
+  axios@1.17.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
       form-data: 4.0.5
-      https-proxy-agent: 5.0.1
+      https-proxy-agent: 5.0.1(supports-color@8.1.1)
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -8186,6 +8245,19 @@ snapshots:
       vue-eslint-parser: 10.4.1(eslint@10.4.1(jiti@2.7.0))
       xml-name-validator: 4.0.0
 
+  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      natural-compare: 1.4.0
+      nth-check: 2.1.1
+      postcss-selector-parser: 7.1.4
+      semver: 7.8.4
+      vue-eslint-parser: 10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      xml-name-validator: 4.0.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+
   eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0))):
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
@@ -8225,7 +8297,44 @@ snapshots:
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-helpers': 0.6.0
+      '@eslint/core': 1.2.1
+      '@eslint/plugin-kit': 0.7.2
+      '@humanfs/node': 0.16.8
+      '@humanwhocodes/module-importer': 1.0.1
+      '@humanwhocodes/retry': 0.4.3
+      '@types/estree': 1.0.9
+      ajv: 6.15.0
+      cross-spawn: 7.0.6
+      debug: 4.4.3(supports-color@8.1.1)
+      escape-string-regexp: 4.0.0
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      esutils: 2.0.3
+      fast-deep-equal: 3.1.3
+      file-entry-cache: 8.0.0
+      find-up: 5.0.0
+      glob-parent: 6.0.2
+      ignore: 5.3.2
+      imurmurhash: 0.1.4
+      is-glob: 4.0.3
+      json-stable-stringify-without-jsonify: 1.0.1
+      minimatch: 10.2.5
+      natural-compare: 1.4.0
+      optionator: 0.9.4
+    optionalDependencies:
+      jiti: 2.7.0
+    transitivePeerDependencies:
+      - supports-color
+
+  eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1):
+    dependencies:
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))
+      '@eslint-community/regexpp': 4.12.2
+      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -8628,9 +8737,9 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1:
+  https-proxy-agent@5.0.1(supports-color@8.1.1):
     dependencies:
-      agent-base: 6.0.2
+      agent-base: 6.0.2(supports-color@8.1.1)
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -9717,7 +9826,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@3.0.11:
+  start-server-and-test@3.0.11(supports-color@8.1.1):
     dependencies:
       arg: 5.0.2
       check-more-types: 2.24.0
@@ -9725,7 +9834,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 2.0.3
       tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3)
+      wait-on: 9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -9940,13 +10049,13 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typescript-eslint@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3):
+  typescript-eslint@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
       '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)
+      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10212,6 +10321,18 @@ snapshots:
 
   vue-component-type-helpers@3.3.4: {}
 
+  vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint-scope: 9.1.2
+      eslint-visitor-keys: 5.0.1
+      espree: 11.2.0
+      esquery: 1.7.0
+      semver: 7.8.4
+    transitivePeerDependencies:
+      - supports-color
+
   vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
@@ -10294,9 +10415,9 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wait-on@9.0.10(debug@4.4.3):
+  wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
     dependencies:
-      axios: 1.17.0(debug@4.4.3)
+      axios: 1.17.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
       joi: 18.2.1
       lodash: 4.18.1
       minimist: 1.2.8

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,16 +10,16 @@ importers:
     dependencies:
       '@typescript-eslint/utils':
         specifier: ^8.60.0
-        version: 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
       typescript-eslint:
         specifier: ^8.60.0
-        version: 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+        version: 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       vue-eslint-parser:
         specifier: ^10.4.0
-        version: 10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+        version: 10.4.1(eslint@10.5.0(jiti@2.7.0))
     devDependencies:
       '@tsconfig/node24':
         specifier: ^24.0.4
@@ -29,10 +29,10 @@ importers:
         version: 22.19.21
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       execa:
         specifier: ^9.6.1
         version: 9.6.1
@@ -50,7 +50,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.7
-        version: 4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue:
         specifier: ^3.5.35
         version: 3.5.38(typescript@6.0.3)
@@ -78,13 +78,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -93,7 +93,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/api-before-14.3:
     dependencies:
@@ -124,10 +124,10 @@ importers:
         version: 5.1.5(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@vitest/eslint-plugin':
         specifier: ^1.6.18
-        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
-        version: 10.2.0(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)
+        version: 10.2.0(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3)
       '@vue/eslint-config-typescript':
         specifier: workspace:*
         version: link:../..
@@ -142,25 +142,25 @@ importers:
         version: 15.17.0
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-cypress:
         specifier: ^6.4.1
-        version: 6.4.1(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))
+        version: 6.4.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       prettier:
         specifier: 3.8.3
         version: 3.8.3
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11(supports-color@8.1.1)
+        version: 3.0.11
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -169,13 +169,13 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.2
-        version: 8.1.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vitest:
         specifier: ^4.1.7
-        version: 4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/custom-type-checked-rules-on-and-off:
     dependencies:
@@ -200,13 +200,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -215,10 +215,10 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.2
-        version: 8.1.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/disable-ts-in-templates:
     dependencies:
@@ -243,13 +243,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -258,7 +258,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/disable-type-checked-for-yml:
     dependencies:
@@ -289,10 +289,10 @@ importers:
         version: 5.1.5(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@vitest/eslint-plugin':
         specifier: ^1.6.18
-        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
-        version: 10.2.0(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)
+        version: 10.2.0(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3)
       '@vue/eslint-config-typescript':
         specifier: workspace:*
         version: link:../..
@@ -307,28 +307,28 @@ importers:
         version: 15.17.0
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-cypress:
         specifier: ^6.4.1
-        version: 6.4.1(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))
+        version: 6.4.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       eslint-plugin-yml:
         specifier: ^3.3.2
-        version: 3.4.0(eslint@10.4.1(jiti@2.7.0))
+        version: 3.4.0(eslint@10.5.0(jiti@2.7.0))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       prettier:
         specifier: 3.8.3
         version: 3.8.3
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11(supports-color@8.1.1)
+        version: 3.0.11
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -337,13 +337,13 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.2
-        version: 8.1.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vitest:
         specifier: ^4.1.7
-        version: 4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/minimal:
     dependencies:
@@ -368,13 +368,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -383,7 +383,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/quasar-project:
     dependencies:
@@ -392,7 +392,7 @@ importers:
         version: 2.0.1
       quasar:
         specifier: ^2.19.3
-        version: 2.20.0
+        version: 2.20.1
       vue:
         specifier: ^3.5.35
         version: 3.5.38(typescript@6.0.3)
@@ -402,16 +402,16 @@ importers:
     devDependencies:
       '@eslint/js':
         specifier: ^10.0.1
-        version: 10.0.1(eslint@10.4.1(jiti@2.7.0))
+        version: 10.0.1(eslint@10.5.0(jiti@2.7.0))
       '@quasar/app-vite':
         specifier: ^2.6.1
-        version: 2.6.2(@quasar/extras@2.0.1)(@types/node@22.19.21)(eslint@10.4.1(jiti@2.7.0))(jiti@2.7.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.0)(rolldown@1.0.3)(rollup@4.61.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)
+        version: 2.6.2(@quasar/extras@2.0.1)(@types/node@22.19.21)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.1)(rolldown@1.0.3)(rollup@4.62.2)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)
       '@types/node':
         specifier: ^22.19.19
         version: 22.19.21
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
-        version: 10.2.0(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)
+        version: 10.2.0(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3)
       '@vue/eslint-config-typescript':
         specifier: workspace:*
         version: link:../..
@@ -420,10 +420,10 @@ importers:
         version: 10.5.0(postcss@8.5.15)
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       globals:
         specifier: ^17.6.0
         version: 17.6.0
@@ -435,10 +435,10 @@ importers:
         version: 6.0.3
       vite-plugin-checker:
         specifier: ^0.14.1
-        version: 0.14.1(eslint@10.4.1(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3))
+        version: 0.14.4(eslint@10.5.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/type-checked:
     dependencies:
@@ -469,10 +469,10 @@ importers:
         version: 5.1.5(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@vitest/eslint-plugin':
         specifier: ^1.6.18
-        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
-        version: 10.2.0(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)
+        version: 10.2.0(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3)
       '@vue/eslint-config-typescript':
         specifier: workspace:*
         version: link:../..
@@ -487,25 +487,25 @@ importers:
         version: 15.17.0
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-cypress:
         specifier: ^6.4.1
-        version: 6.4.1(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))
+        version: 6.4.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       prettier:
         specifier: 3.8.3
         version: 3.8.3
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11(supports-color@8.1.1)
+        version: 3.0.11
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -514,13 +514,13 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.2
-        version: 8.1.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vitest:
         specifier: ^4.1.7
-        version: 4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-cypress:
     dependencies:
@@ -548,19 +548,19 @@ importers:
         version: 15.17.0
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-cypress:
         specifier: ^6.4.1
-        version: 6.4.1(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))
+        version: 6.4.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       start-server-and-test:
         specifier: ^3.0.5
-        version: 3.0.11(supports-color@8.1.1)
+        version: 3.0.11
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -569,7 +569,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-jsx:
     dependencies:
@@ -597,13 +597,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -612,7 +612,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-jsx-in-vue:
     dependencies:
@@ -640,13 +640,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -655,7 +655,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-playwright:
     dependencies:
@@ -665,7 +665,7 @@ importers:
     devDependencies:
       '@playwright/test':
         specifier: ^1.60.0
-        version: 1.60.0
+        version: 1.61.0
       '@tsconfig/node24':
         specifier: ^24.0.4
         version: 24.0.4
@@ -683,16 +683,16 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-playwright:
         specifier: ^2.10.4
-        version: 2.10.4(eslint@10.4.1(jiti@2.7.0))
+        version: 2.10.4(eslint@10.5.0(jiti@2.7.0))
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -701,7 +701,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-prettier:
     dependencies:
@@ -720,7 +720,7 @@ importers:
         version: 6.0.7(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@vue/eslint-config-prettier':
         specifier: ^10.2.0
-        version: 10.2.0(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)
+        version: 10.2.0(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3)
       '@vue/eslint-config-typescript':
         specifier: workspace:*
         version: link:../..
@@ -729,13 +729,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       prettier:
         specifier: 3.8.3
         version: 3.8.3
@@ -747,7 +747,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-tsx:
     dependencies:
@@ -775,13 +775,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -790,7 +790,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-tsx-in-vue:
     dependencies:
@@ -818,13 +818,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -833,7 +833,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   examples/with-vitest:
     dependencies:
@@ -855,7 +855,7 @@ importers:
         version: 6.0.7(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@vitest/eslint-plugin':
         specifier: ^1.6.18
-        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
+        version: 1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))
       '@vue/eslint-config-typescript':
         specifier: workspace:*
         version: link:../..
@@ -867,16 +867,16 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       jsdom:
         specifier: ^29.1.1
         version: 29.1.1
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -885,10 +885,10 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.7
-        version: 4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   test/fixtures/custom-ignored-directory:
     dependencies:
@@ -913,16 +913,16 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -931,10 +931,10 @@ importers:
         version: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.2
-        version: 8.1.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   test/fixtures/file-based-routing:
     dependencies:
@@ -962,13 +962,13 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -977,10 +977,10 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.2
-        version: 8.1.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   test/fixtures/redefine-plugin-vue:
     dependencies:
@@ -1005,16 +1005,16 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.0.0
-        version: 10.0.1(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.0.1(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       jiti:
         specifier: ^2.7.0
         version: 2.7.0
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -1023,10 +1023,10 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-vue-devtools:
         specifier: ^8.1.2
-        version: 8.1.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+        version: 8.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   test/fixtures/with-older-espree:
     dependencies:
@@ -1051,16 +1051,16 @@ importers:
         version: 0.9.1(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       espree:
         specifier: ^9.6.1
         version: 9.6.1
       npm-run-all2:
         specifier: ^9.0.1
-        version: 9.0.1
+        version: 9.0.2
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -1069,7 +1069,7 @@ importers:
         version: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue-tsc:
         specifier: ^3.3.2
-        version: 3.3.4(typescript@6.0.3)
+        version: 3.3.5(typescript@6.0.3)
 
   test/fixtures/with-vue-ts-api:
     dependencies:
@@ -1082,10 +1082,10 @@ importers:
         version: link:../../..
       eslint:
         specifier: ^10.4.0
-        version: 10.4.1(jiti@2.7.0)
+        version: 10.5.0(jiti@2.7.0)
       eslint-plugin-vue:
         specifier: ~10.9.1
-        version: 10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)))
+        version: 10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)))
       typescript:
         specifier: ~6.0.0
         version: 6.0.3
@@ -1123,8 +1123,8 @@ packages:
     resolution: {integrity: sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/generator@8.0.0-rc.6':
-    resolution: {integrity: sha512-6mIzgVK8DgEzvIapoQwhXTMnnkuE4STQmVv9H03i/tZ2ml8oev3TRvZJgTenK2Bsq0YWNtzOrFdTyNzCMFtjJQ==}
+  '@babel/generator@8.0.0':
+    resolution: {integrity: sha512-NT9NrVwJsbSV6Y2FSstWa71EETOnzrjkL5/wX3D2mYHtKM+qvqB1DvR4D0Setb/gDBsHzRICifwEWMO8CnTF6g==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-annotate-as-pure@7.29.7':
@@ -1181,16 +1181,16 @@ packages:
     resolution: {integrity: sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-string-parser@8.0.0-rc.6':
-    resolution: {integrity: sha512-BCkFy+zN6kXQed3YOT7aJl93NfDSzQc3pBfsvTVPs9gU9X3V0aefEF5kwBT0E+mDWH9QgKaZstYUQN9VdQZT4g==}
+  '@babel/helper-string-parser@8.0.0':
+    resolution: {integrity: sha512-6mJgmFFFIIO82vvoLt9XtRC7/TkzXfts1t/SpRX4IHSzMgqoPYCWesVu1udUPUWioAE/2fcG6WuI8zrkE1gwrg==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-identifier@7.29.7':
     resolution: {integrity: sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.6':
-    resolution: {integrity: sha512-nVJ+1JcCgntv8d78rRo++o2wuODT0Irknx2BF8Np4Ft2CRgjLqIs4qzSZ8b66yGbBdMWGmZBO9WEZv1hhNiSpg==}
+  '@babel/helper-validator-identifier@8.0.2':
+    resolution: {integrity: sha512-9Fr9QeyCAyi1BR1jKZ6uYQ24EIhQUx5ReHfQU7drOE+TPOb+w11/dsqLkMOT2U29OdCT71XajrOT8xDc1C7orA==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@babel/helper-validator-option@7.29.7':
@@ -1206,8 +1206,8 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  '@babel/parser@8.0.0-rc.6':
-    resolution: {integrity: sha512-rOS8IpdO7mQELkTPlCsTgPejO0bFuZdEDCGQJouYbYf9e1FLTym7Fei2pEjq8q7MWbX0ravcd7QQYKs1TxOuog==}
+  '@babel/parser@8.0.0':
+    resolution: {integrity: sha512-aLxAE+imI9bCcyaPrUDjBv3uSkWieifjLe0kuFOZF0zli0L6GCsTmsePnTr55adbIAgYz2zhN1vnFimCBUYcRQ==}
     engines: {node: ^22.18.0 || >=24.11.0}
     hasBin: true
 
@@ -1264,8 +1264,8 @@ packages:
     resolution: {integrity: sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==}
     engines: {node: '>=6.9.0'}
 
-  '@babel/types@8.0.0-rc.6':
-    resolution: {integrity: sha512-p7/ABylAYlexb31wtRdIfH9L9A0Z2T/9H6zAqzqndkY2PLkvNNc580wGhp/gGKN4Sp9sQvSkhc6Oga8/O+wTyw==}
+  '@babel/types@8.0.0':
+    resolution: {integrity: sha512-K8ponJDxBwDHigkeFqaqT5wLGl4bTlwMafR8k7b5CPxr6Ww+UG9ls8Yx6Tcpboxu97eeGVEEyKcHmEyOwN1vSw==}
     engines: {node: ^22.18.0 || >=24.11.0}
 
   '@bramus/specificity@2.4.2':
@@ -1286,8 +1286,8 @@ packages:
       '@csstools/css-parser-algorithms': ^4.0.0
       '@csstools/css-tokenizer': ^4.0.0
 
-  '@csstools/css-color-parser@4.1.3':
-    resolution: {integrity: sha512-DOgvIPkikIOixQRlD4YF31VN6fLLUTdrzhfRbis8vm0kMTgIbEPX0Ip/YX9fOeV9iywAS4sUUbTclpan7yYP8Q==}
+  '@csstools/css-color-parser@4.1.8':
+    resolution: {integrity: sha512-3chWb7PRLijpJpPIKkDxdu6IBeO5MrFACND57On0j8OPpc0wZibcGc3xAHrSEbOx/KDRyMHoIxGn0w1PhXMYHw==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@csstools/css-parser-algorithms': ^4.0.0
@@ -2205,8 +2205,8 @@ packages:
     resolution: {integrity: sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.60.0':
-    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
+  '@playwright/test@1.61.0':
+    resolution: {integrity: sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -2416,141 +2416,141 @@ packages:
       rollup:
         optional: true
 
-  '@rollup/rollup-android-arm-eabi@4.61.1':
-    resolution: {integrity: sha512-JnBB8MdXj45cajvTuO5FmPlvFVJRQgvrz1uSEl3NwqFnReAPGwb8EanbGi4z2nRaqLzjJSv5/JmycoTKlRZxHA==}
+  '@rollup/rollup-android-arm-eabi@4.62.2':
+    resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
     cpu: [arm]
     os: [android]
 
-  '@rollup/rollup-android-arm64@4.61.1':
-    resolution: {integrity: sha512-Jx2g7iSjw4AOT0HDPHM9RV3GNjRXwybWtSFZiZAYUTjUwjVrYIwq3kBf+LnhqJlzXFAqTAh2F7IGI+O568exPw==}
+  '@rollup/rollup-android-arm64@4.62.2':
+    resolution: {integrity: sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==}
     cpu: [arm64]
     os: [android]
 
-  '@rollup/rollup-darwin-arm64@4.61.1':
-    resolution: {integrity: sha512-0F1L/Z3Eqv8mT2n3dCpeO8GcTvHvVqkP5/t6DMsn0KzhYVcg+s7Ncl5DS8qjKYEeio6Az0Gt6nyBORay5qIlCA==}
+  '@rollup/rollup-darwin-arm64@4.62.2':
+    resolution: {integrity: sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==}
     cpu: [arm64]
     os: [darwin]
 
-  '@rollup/rollup-darwin-x64@4.61.1':
-    resolution: {integrity: sha512-qLttcH871ujY4YcVfUSShhOw+CsoTatYz8gRbHO7Bb92QH059/P0y5do1KMs41fY0BpD2x4AJH/gID0zFiqVKQ==}
+  '@rollup/rollup-darwin-x64@4.62.2':
+    resolution: {integrity: sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==}
     cpu: [x64]
     os: [darwin]
 
-  '@rollup/rollup-freebsd-arm64@4.61.1':
-    resolution: {integrity: sha512-fUI4RapGE0Oh3mb8mgfvC1O2nU1RpDZUKnDQm3xB1Ipg7C2wTs5Kstz7G2uWK99a8S2yTMq8/P4uycwNa0nJyw==}
+  '@rollup/rollup-freebsd-arm64@4.62.2':
+    resolution: {integrity: sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==}
     cpu: [arm64]
     os: [freebsd]
 
-  '@rollup/rollup-freebsd-x64@4.61.1':
-    resolution: {integrity: sha512-H5YrdvJaDtI/U9/emrD4b++xkvp3y/JvOe4rizHbxvkyMfRS/CiRYdji+Pl8D0brEaNFWUh1drQxgAGIl6Xudw==}
+  '@rollup/rollup-freebsd-x64@4.62.2':
+    resolution: {integrity: sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==}
     cpu: [x64]
     os: [freebsd]
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
-    resolution: {integrity: sha512-Q8CBCCQtDFrYtXoeUXSrnFXKOnyUhx6bz+SkL6A0E7V8kAiCJ5pamq1WtbfpVGhR5TSpXY6ak3avmDc5fHTyJA==}
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
+    resolution: {integrity: sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==}
     cpu: [arm]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
-    resolution: {integrity: sha512-nwnhk1581l0FBVellGcVCAT0Oi06onEA3WB53sf01VO3I0UPBkMH9sXONYME2K0ovXcNayJfNtHfm6mpJElatQ==}
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
+    resolution: {integrity: sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==}
     cpu: [arm]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
-    resolution: {integrity: sha512-x5Xr49hwt3hdW75UOZm3395YwwzPyauktslv29KpWL/T+vVAzoT3azLcTWv0eMciBNrx+DYjH4paehHoLpPvpg==}
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
+    resolution: {integrity: sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
-    resolution: {integrity: sha512-unMS3H73DpaoPyyEVPjGKleM/s0mkmsauTENpw4INQY8y4+IuLNjkueQ5QCtC0D3N38Y38yhAU8OoZ20S2Tm6w==}
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
+    resolution: {integrity: sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
-    resolution: {integrity: sha512-zNZzGRnAhwjFEYmvphJRV5XaQGjs62cCmeYYHUT//NbvEnHauw+I85nGG+SiVg5ld4GX8D1IbKIX+ozITQnhMQ==}
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
+    resolution: {integrity: sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==}
     cpu: [loong64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
-    resolution: {integrity: sha512-LdpWGL8X209B2SIvWjqlc8VZgM6PKfontSerGepuldQmHYrAOtnMCXeJkxXGbC+PPZVOuu5czJo7fNV6aeW8rQ==}
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
+    resolution: {integrity: sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==}
     cpu: [loong64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
-    resolution: {integrity: sha512-EC5kTtNaNGOmbMGqar8dvJy6y/hg99GAwjfBz++pxZhQATXGcRjd6c5en5wcbru0vkRmiMGsQKdMJOOf6sza4g==}
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
+    resolution: {integrity: sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
-    resolution: {integrity: sha512-8hiwp6D4acEcNK78I4rP0/XtS1sknWIAMJBPdR4l6zUtyTm5KiTDr5bXmWt4foY7nAN7AThDHgkLIEZOWKbzWw==}
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
+    resolution: {integrity: sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==}
     cpu: [ppc64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
-    resolution: {integrity: sha512-10dh/h/BqA7DuMPWSxkR8uks18FRwnwOEqr5zOTEl+NOwP/OMzKX8OFR/Of9xxDA7D5qef1Nzar5WDD2kCCr1g==}
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
+    resolution: {integrity: sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==}
     cpu: [riscv64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
-    resolution: {integrity: sha512-YKJ5lg35DP17gcAOggnihe+APw9HLyj1Xn7gsmGumBJAUDa6NGXNixJzmkWLhcK9TOuuyQjdamzvJefkO7qHZQ==}
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
+    resolution: {integrity: sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==}
     cpu: [riscv64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
-    resolution: {integrity: sha512-Mlil5G2Jj6a7B3LWGctg+XPL9vdXYuzCtNXfxOQ0nPjc2m6ueUktocPGH9bnAM0bNRKb/bAWTujUU7IJQdQA+g==}
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
+    resolution: {integrity: sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-bVWIOIk6pV01p4CdUbPP7CJ/434z+OooYjDuFcR+44N35YvKUC66G8MGnvcWx5mWKW3g61J+t74l3Kj15Kwn2Q==}
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rollup/rollup-linux-x64-musl@4.61.1':
-    resolution: {integrity: sha512-qy5pBvZbqNFheBz61R1rzsezjm0J7O2oNGoWtGoY89SZYLUfxAJTBAqDChqAIdB4rCiIbi9nF7yZ83GnNiLwSw==}
+  '@rollup/rollup-linux-x64-musl@4.62.2':
+    resolution: {integrity: sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rollup/rollup-openbsd-x64@4.61.1':
-    resolution: {integrity: sha512-E83TXjI4zm0+5f2qO+UOudaCYIhYwpJ5jq6YCZNIZ+6CbfhKrkAGezeiASBL9ElxAxFsRS9ZhESv8mfnj6TKeg==}
+  '@rollup/rollup-openbsd-x64@4.62.2':
+    resolution: {integrity: sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==}
     cpu: [x64]
     os: [openbsd]
 
-  '@rollup/rollup-openharmony-arm64@4.61.1':
-    resolution: {integrity: sha512-fbWnKqVkjrJN38vNe3ahkbk6iejS/3b0Nt7EEtPpE6RBacZcGXNKbzfHN3GUUlXOPghUg0j6XUGrtjX9z1sIvA==}
+  '@rollup/rollup-openharmony-arm64@4.62.2':
+    resolution: {integrity: sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
-    resolution: {integrity: sha512-ArMl38iVAbk0New1ogihQNY6iphLi4ZaRsa037gUzv5yeKPY8TD3Dmy4x2RNC1VztU/uqm+G+/RwFrSka3Oy2g==}
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
+    resolution: {integrity: sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==}
     cpu: [arm64]
     os: [win32]
 
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
-    resolution: {integrity: sha512-0mYtjHS9ucAbcATycCNK9IGBk/cCe/ma7EmSLGZdsxnOA8cjRIyU04wDpVAD9NiOfLUR9KTxdiO53uOkherqjQ==}
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
+    resolution: {integrity: sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==}
     cpu: [ia32]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
-    resolution: {integrity: sha512-gK1iCEPfpoSG9wfBihXxvBMi8ZfcWffYkEsC/Eih+iFENTaewvNcrEQ69lIOWYO5pePHKLHHO7nq5AILGO/HQQ==}
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
+    resolution: {integrity: sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==}
     cpu: [x64]
     os: [win32]
 
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
-    resolution: {integrity: sha512-X+zaP2x+j4RXGfbp/seSoRHWnPxzApilDszisZxbYH5C/jTxFhCtDNdPGZb9lJyYPs24wGxruPF7Y+sIXt9Gzw==}
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
+    resolution: {integrity: sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==}
     cpu: [x64]
     os: [win32]
 
@@ -2657,63 +2657,63 @@ packages:
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
 
-  '@typescript-eslint/eslint-plugin@8.61.0':
-    resolution: {integrity: sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==}
+  '@typescript-eslint/eslint-plugin@8.61.1':
+    resolution: {integrity: sha512-ZPlVl3PB3et/59Ne0fv/sci6ZXz4T4Hp4nTJ56i/Y0gR89ARb+KphojTq6j+56E5PIezmOIOOWyY+aWQFd+IkQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
-      '@typescript-eslint/parser': ^8.61.0
+      '@typescript-eslint/parser': ^8.61.1
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/parser@8.61.0':
-    resolution: {integrity: sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/project-service@8.61.0':
-    resolution: {integrity: sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/scope-manager@8.61.0':
-    resolution: {integrity: sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/tsconfig-utils@8.61.0':
-    resolution: {integrity: sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-    peerDependencies:
-      typescript: '>=4.8.4 <6.1.0'
-
-  '@typescript-eslint/type-utils@8.61.0':
-    resolution: {integrity: sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==}
+  '@typescript-eslint/parser@8.61.1':
+    resolution: {integrity: sha512-PJ5vePq5/ognBbrIcoC5+SHO5dfpeLPzP9FpLkzWrguoYQEeeSjlJpVwOpo1JRSTEi7dRcwNy4h4dzV70PqHcg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/types@8.61.0':
-    resolution: {integrity: sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==}
-    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  '@typescript-eslint/typescript-estree@8.61.0':
-    resolution: {integrity: sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==}
+  '@typescript-eslint/project-service@8.61.1':
+    resolution: {integrity: sha512-PrC4JYGmR241lYnfhmKGTXkFqv8+ymbTFgSAY0fVXpY82/QkMw5TZPl+vGzuDDU2QYJk9fIDOBTntF+yDv9LEA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/utils@8.61.0':
-    resolution: {integrity: sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==}
+  '@typescript-eslint/scope-manager@8.61.1':
+    resolution: {integrity: sha512-L2bdIeoQS8FlKAvONAr20w6OcLXeB+qiDKbAooS9A0Ben+iSIkBef0FxqwKWYqt5sa0i4KJtxVyVmhMylKzF5w==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/tsconfig-utils@8.61.1':
+    resolution: {integrity: sha512-UN/H4di+OO7EWx2ovME+8t31YO+KVnK0RRKEHR3kOt21/Ay8BOq3M1OMvWs5vNiqcFCYGYoxK3MXPZzmMUE+yg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/type-utils@8.61.1':
+    resolution: {integrity: sha512-GYRicKmVK0C4fsKgaACaknOUAq9Oa2kwsjnpFhFcS/5p4Ht5IP9OVLbgIgcK4SRk92nVHFluurg1lumD9dBcLw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
       typescript: '>=4.8.4 <6.1.0'
 
-  '@typescript-eslint/visitor-keys@8.61.0':
-    resolution: {integrity: sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==}
+  '@typescript-eslint/types@8.61.1':
+    resolution: {integrity: sha512-G+CRlPqLv7Bz1IZVs03x5K59F1veqL0EJUROAdGhKsEq8qOiRiZbI+HUojPq5l0fEGOKModD9br6lObhB8zkoA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript-eslint/typescript-estree@8.61.1':
+    resolution: {integrity: sha512-u+oQD3BqYWPc8YV9Zab4vaJElJuwOLPRc10Jm1o/qS+6Qwen14HCWwx0Seo4LnSn2wxea2Ik8DxPt2/FHmuhrg==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/utils@8.61.1':
+    resolution: {integrity: sha512-1+P/3Dj6jvtybE1q0HQ6yBt/gq+oKJyLdEv4HdnqasaEXRSYCAsD59mXEVQnM/ULNdQxbX77tdG4jPRjIS6knA==}
+    engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    peerDependencies:
+      eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
+      typescript: '>=4.8.4 <6.1.0'
+
+  '@typescript-eslint/visitor-keys@8.61.1':
+    resolution: {integrity: sha512-6fJ9MHWtK14C1DSkiMlHUSOmrVebL7150xZJBlJiL62jjhIA4JmOq6flwBgDxIdBKKdoiZRel+dfPD5MLfny3w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
   '@vitejs/plugin-vue-jsx@5.1.5':
@@ -2746,11 +2746,11 @@ packages:
       vitest:
         optional: true
 
-  '@vitest/expect@4.1.8':
-    resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
+  '@vitest/expect@4.1.9':
+    resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
-  '@vitest/mocker@4.1.8':
-    resolution: {integrity: sha512-LEiN/xe4OSIbKe9HQIp5OC24agGD9J5CnmMgsLohVVoOPWL9a2sBoR6VBx43jQZb7Kr1l4RCuyCJzcAa0+dojw==}
+  '@vitest/mocker@4.1.9':
+    resolution: {integrity: sha512-EVkXzBjrPGM+cK8/ANWgBrkUCfJfb38/EfTSO8h7pWvKkyPkpWxvR7BkD2MyItMF62C97zAEoqdpUixwR/e+Rw==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -2760,20 +2760,20 @@ packages:
       vite:
         optional: true
 
-  '@vitest/pretty-format@4.1.8':
-    resolution: {integrity: sha512-9GasEBxpZ1VYIpqHf/0+YGg121uSNwCKOJqIrTwWP/TB7DmFCiaBpNl3aPZzoLWfWkuqhbH8vJIVobZkvdo2cA==}
+  '@vitest/pretty-format@4.1.9':
+    resolution: {integrity: sha512-s0iufns3iIFitdgm+YR7g1whCAaGtXz459VS9/PqyKDEEFgYIhsHOQmXgIgDuYCt7DeQmiZT0Qe2OA2p4ZPu5A==}
 
-  '@vitest/runner@4.1.8':
-    resolution: {integrity: sha512-EmVxeBAfMJvycdjd6Hm+RbFBbA9fKvo0Kx37hNpBYoYeavH3RNsBXWDooR1mgD52dCrxIIuP7UotpfiwOikvcg==}
+  '@vitest/runner@4.1.9':
+    resolution: {integrity: sha512-KXLMDtc7oe70+3mJfGrPUWPesswH+3sTxAMAMl8DG7I8IUQT4XW718dY5ID3vPUcmlu27CcKfY4P3h3I29SLJg==}
 
-  '@vitest/snapshot@4.1.8':
-    resolution: {integrity: sha512-acfZboRmAIf05DEKcBQy33VXojFJjtUdLyo7oOmV9kebb2xdU01UknNiPuPZoJZQyO7DF0gZdTGTpeAzET9QPQ==}
+  '@vitest/snapshot@4.1.9':
+    resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
 
-  '@vitest/spy@4.1.8':
-    resolution: {integrity: sha512-6EevtBp6OZOPF7bmz36HrGMeP3txgVSrgebWxHOafDXGkhIzfXK14f8KF6MuFfgXXUeHxmpD3BQxkV00/3s5mA==}
+  '@vitest/spy@4.1.9':
+    resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
 
-  '@vitest/utils@4.1.8':
-    resolution: {integrity: sha512-uOJamYALNhfJ6iolExyQM40yIQwDqYnkKtQ5VCiSe17E33H0aQ/u+1GlRuz4LZBk6Mm3sg90G9hEbmEt37C1Zg==}
+  '@vitest/utils@4.1.9':
+    resolution: {integrity: sha512-A51o8ymO5PpqlWNnBP9ZHPXDIpuMtTLlGSjN7la4US+LJzoUMyhwjA5QXlm39JexgwHKW4Xjs8Z2d3dLCXOeuA==}
 
   '@volar/language-core@2.4.28':
     resolution: {integrity: sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==}
@@ -2840,25 +2840,25 @@ packages:
   '@vue/devtools-api@7.7.9':
     resolution: {integrity: sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==}
 
-  '@vue/devtools-api@8.1.2':
-    resolution: {integrity: sha512-vA0O112YqyDuNA1s7Yb2gCgToQ/OxOWiFDO5ThLCcDy0ldHnSd1dUTaSYhOldbqoNgumE4dxtGAoAaSUKUD1Zg==}
+  '@vue/devtools-api@8.1.3':
+    resolution: {integrity: sha512-73NMCvxXh8Hyozc/jiwqTFWVcCMyi11U1zmrq4DoukQJnuo8JHt6FsNu4HdeUDa8SpIp5vb7Q22GWgIq0efsXg==}
 
-  '@vue/devtools-core@8.1.2':
-    resolution: {integrity: sha512-ZGGyaSBP4/+bN2Nd9ZHNYAVDRIzMw1rv2RyXWtyZlo6mQal+IDmTvKY4V+DjAEBhaXt30mHmsgYp1yXJ/2tIWg==}
+  '@vue/devtools-core@8.1.3':
+    resolution: {integrity: sha512-xezkv5/CPH/o5C8PE2Len9MnTJMsctYYQbKbbUiNOJpKd+fRHj27nKDb/sbtYI8NSQduegeQhCJGKRgAiOV6Uw==}
     peerDependencies:
       vue: ^3.0.0
 
   '@vue/devtools-kit@7.7.9':
     resolution: {integrity: sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==}
 
-  '@vue/devtools-kit@8.1.2':
-    resolution: {integrity: sha512-f75/upc+GCyjXErpgPGz4582ujS0L/adAltGy+tqXMGUJpgAcfGr6CxnnhpZY8BHuMYt6KpbF8uaFrrQG66rGQ==}
+  '@vue/devtools-kit@8.1.3':
+    resolution: {integrity: sha512-cRn7GXiCQkMYU2Z3h3pM4YO/ndbx9FY1yLDAqIqPLcmIq4H6zAOJHein6tvZU3AfPwgrodqLiPBEF+YQaS8AxA==}
 
   '@vue/devtools-shared@7.7.9':
     resolution: {integrity: sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==}
 
-  '@vue/devtools-shared@8.1.2':
-    resolution: {integrity: sha512-X9RyVFYAdkBe4IUf5v48TxBF/6QPmF8CmWrDAjXzfUHrgQ/HGfTC1A6TqgXqZ03ye66l3AD51BAGD69IvKM9sw==}
+  '@vue/devtools-shared@8.1.3':
+    resolution: {integrity: sha512-CM3uIPL+v+lrJUk33+pxspYo0MhuMWlCvf7zC9fybifvCPyM2jUbYRPwoYEJgYbwRqPikm5HozbUhp60MF2QuA==}
 
   '@vue/eslint-config-prettier@10.2.0':
     resolution: {integrity: sha512-GL3YBLwv/+b86yHcNNfPJxOTtVFJ4Mbc9UU3zR+KVoG7SwGTjPT+32fXamscNumElhcpXW3mT0DgzS9w32S7Bw==}
@@ -2866,8 +2866,8 @@ packages:
       eslint: '>= 8.21.0'
       prettier: '>= 3.0.0'
 
-  '@vue/language-core@3.3.4':
-    resolution: {integrity: sha512-IuHqQ5zGGOE7CXP72VX6A42IVeIzYv4WAhO6arej11TRNqtdZfGyH8Yr2FOCaDX0dSQG+JwULLoFHGY1igYVjQ==}
+  '@vue/language-core@3.3.5':
+    resolution: {integrity: sha512-UkKu5nhX89fg4VhlG/FOeI10G3cj/7radKT/cy9BT4Q9qJmJlSTAc/dP63Xqs29aypN4f39xUV6PsLNk/dcD6g==}
 
   '@vue/reactivity@3.5.38':
     resolution: {integrity: sha512-pG6LV/NDNRbKizcUjFFLAfjaL8mcv4DmR9avNcUw2gDHBzZneuS2TWCmp633ynzxz9YYKNeEPK2I8Wraqy2HUQ==}
@@ -3030,8 +3030,8 @@ packages:
   aws4@1.13.2:
     resolution: {integrity: sha512-lHe62zvbTB5eEABUVi/AwVh0ZKY9rMMDhmm+eeyuuUQbQ3+J+fONVQOZyj+DdrvD4BY33uYniyRJ4UJIaSKAfw==}
 
-  axios@1.17.0:
-    resolution: {integrity: sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==}
+  axios@1.18.0:
+    resolution: {integrity: sha512-E32NzpYKp++W7XRe52rHiXV2ehxmh3wbdgO7MHeFM+vqxLBYHzt0ElkiImtOBxtOmyp0yoC8C6uESVV84Y2/hw==}
 
   b4a@1.8.1:
     resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
@@ -3092,8 +3092,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  baseline-browser-mapping@2.10.36:
-    resolution: {integrity: sha512-lVq/Df7LXlO79MVaaUHztSwWiG9oXoWHlgvNS51v8Dpd4+G4/VIy6qYePTw31nAVls33nUtnfezYeLkYAak9dg==}
+  baseline-browser-mapping@2.10.38:
+    resolution: {integrity: sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -3192,8 +3192,8 @@ packages:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
 
-  chardet@2.1.1:
-    resolution: {integrity: sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ==}
+  chardet@2.2.0:
+    resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
   check-more-types@2.24.0:
     resolution: {integrity: sha512-Pj779qHxV2tuapviy1bSZNEL1maXr13bPYpsvSDB68HlYcYuhlDrmGd63i0JHMCLKzc7rUSNIrpdJlhVlNwrxA==}
@@ -3471,8 +3471,8 @@ packages:
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
-  electron-to-chromium@1.5.372:
-    resolution: {integrity: sha512-M3yhbAlilnwqC8D21t28UCDGHyitShTmmLRU/H+b74P6Ski16Nb9HONYEaVpMj/pwC7BEo5B95FpjODLCWbtfA==}
+  electron-to-chromium@1.5.376:
+    resolution: {integrity: sha512-cUVA7/RvbFTEuw/i3obUwDTRIXojaxkResf+ibByPFxjc6XK3VNtcQXV0NSbAlJ0FMjcJGgftVVB4Qo184EXvA==}
 
   elementtree@0.1.7:
     resolution: {integrity: sha512-wkgGT6kugeQk/P6VZ/f4T+4HB41BVgNBq5CDIZVbQ02nvTVqAiVTbskxxu3eA/X96lMlfYOwnLQpN2v5E1zDEg==}
@@ -3636,8 +3636,8 @@ packages:
     resolution: {integrity: sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
 
-  eslint@10.4.1:
-    resolution: {integrity: sha512-AyIKhnOBuOAdueD7RB3xB+YeAWScb9jHsJBgH2Hcde8InP5JYhqrRR6iTMHyTEwgENK54Cp44e4v8BwNhsuHuw==}
+  eslint@10.5.0:
+    resolution: {integrity: sha512-1y+7C+vi12bUK1IpZeaV3gsH9fHLBmPvYmPx42pvT/E9yG0IC8g3PUZZgp0+JLJl7ZDK0flc2gc+Aw9dpCvIsQ==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
     hasBin: true
     peerDependencies:
@@ -3821,8 +3821,8 @@ packages:
   forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+  form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -4143,8 +4143,8 @@ packages:
     resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
     hasBin: true
 
-  joi@18.2.1:
-    resolution: {integrity: sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==}
+  joi@18.2.3:
+    resolution: {integrity: sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==}
     engines: {node: '>= 20'}
 
   js-beautify@1.15.4:
@@ -4448,8 +4448,8 @@ packages:
     resolution: {integrity: sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.13:
+    resolution: {integrity: sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -4470,8 +4470,8 @@ packages:
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
-  node-releases@2.0.47:
-    resolution: {integrity: sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==}
+  node-releases@2.0.48:
+    resolution: {integrity: sha512-1uz8041X6LoI6ZSdZacM9lVY28vuzDlSKitnpbSNK0RfKoIJkX29NBPVEFXhnuSuEOA9Ww0xnPJ+ILWbGAv8DA==}
     engines: {node: '>=18'}
 
   nopt@7.2.1:
@@ -4487,8 +4487,8 @@ packages:
     resolution: {integrity: sha512-tdt4aFn9QamlhdN3HV2D2ccpBwO5/fyjjbXUxYA6uBjyekMZcZvDq0aSj9t5Jo+tih6AYFnt/cuIRn9013e0Uw==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
-  npm-run-all2@9.0.1:
-    resolution: {integrity: sha512-ZtK8WXZBUA9x0XD6nxYdFLe86FxpkCTq2LiQxzX0LeXQY/vyAigQZXjjj/xfTwgV4Yqe/vYNIq2W09lrHKTcuQ==}
+  npm-run-all2@9.0.2:
+    resolution: {integrity: sha512-+dd4SO2jAlLE06OzmJKzIe6QvvjXezcbmobnh8usR0a8BzQCABTdqTXqVPji0ICOhSQpIIrkGd7IzNl5iDaRSA==}
     engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0, npm: '>= 10'}
     hasBin: true
 
@@ -4623,9 +4623,9 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
-  pidtree@0.6.1:
-    resolution: {integrity: sha512-e0F9AOF1JMrCfBsyJOwU9lNvQ0WtXTq0j/4jk0BQ5JSI9VAybPXmDpPRw/2FQ3e5d3ZFN1mLh7jW99m/jjaptw==}
-    engines: {node: '>=0.10'}
+  pidtree@1.0.0:
+    resolution: {integrity: sha512-avfAvjB9Dd0wdj3rjJX//yS+G79OO0KrS5pJHFJENjYGX6N4SMgEDBBI/yFy0lloOYSaC6XQxzpOAMPfSYFV/Q==}
+    engines: {node: '>=18'}
     hasBin: true
 
   pify@2.3.0:
@@ -4661,13 +4661,13 @@ packages:
     resolution: {integrity: sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.60.0:
-    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
+  playwright-core@1.61.0:
+    resolution: {integrity: sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.60.0:
-    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
+  playwright@1.61.0:
+    resolution: {integrity: sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -4756,8 +4756,8 @@ packages:
   quansync@0.2.11:
     resolution: {integrity: sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==}
 
-  quasar@2.20.0:
-    resolution: {integrity: sha512-TIiEF6DG62TlbjivLU8puwWk0XXryTHW2aJMQu5/d37c2ysOp+vWg/1WH77nNRaK5b2lHIb30Y0POgPlqOs4xw==}
+  quasar@2.20.1:
+    resolution: {integrity: sha512-C+uFyt9/D2B2Dad/c9tGSlyWLMsrz+ROJLm3FKFdY9i+vc1Mk2q/+JyHBmQnuvQCEpUrdiXqcWQbpmZhuvo60A==}
     engines: {node: '>= 10.18.1', npm: '>= 6.13.4', yarn: '>= 1.21.1'}
 
   queue-microtask@1.2.3:
@@ -4856,8 +4856,8 @@ packages:
   rollup-pluginutils@2.8.2:
     resolution: {integrity: sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==}
 
-  rollup@4.61.1:
-    resolution: {integrity: sha512-I4KW6iuRpuu2uHBLraZ1wNZe0DP7lnRha+VJ9tNaYVaVgKhW0aI3h4RYnoRPeql0flHm/Co55b7snEDcOfOJrA==}
+  rollup@4.62.2:
+    resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
@@ -5024,8 +5024,8 @@ packages:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
     hasBin: true
 
-  semver@7.8.4:
-    resolution: {integrity: sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==}
+  semver@7.8.5:
+    resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
 
@@ -5033,8 +5033,8 @@ packages:
     resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
     engines: {node: '>= 0.8.0'}
 
-  serialize-javascript@7.0.5:
-    resolution: {integrity: sha512-F4LcB0UqUl1zErq+1nYEEzSHJnIwb3AF2XWB94b+afhrekOUijwooAYqFyRbjYkm2PAKBabx6oYv/xDxNi8IBw==}
+  serialize-javascript@7.0.6:
+    resolution: {integrity: sha512-ATTK5Q4gFVg0YDp1my2vqygyvhcklD/UV5GIlYHooGTn/NogJqIzpetkD6E5kmuVULqz/S9inUL25XcAgDRJQg==}
     engines: {node: '>=20.0.0'}
 
   serve-static@1.16.3:
@@ -5141,8 +5141,8 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
-  streamx@2.27.0:
-    resolution: {integrity: sha512-WZ189TKnHoAokYHvwzaAQMpd55cgUmFIcJFzBSgGcb886jau5DL+XdDhTWV4ps3FLvk+OORp0dLRTPsLZ21CSA==}
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
 
   string-width@4.2.3:
     resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
@@ -5261,15 +5261,15 @@ packages:
   tldts-core@6.1.86:
     resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
 
-  tldts-core@7.4.2:
-    resolution: {integrity: sha512-nwEyF4vl4RSJjwSjBUmOSxc3BFPoIFdlRthJ6e+5v9P3bHNsoD06UjuqMUspqp7vsEZ1beaHi1km+optiE17yA==}
+  tldts-core@7.4.3:
+    resolution: {integrity: sha512-27ep5H9PzdBrNd5OFM/j3WCU8F3kPwM9D0BOaOf7uYfxMJfyr0K5Tjj69Gri+sZlh2WXd5buIm47NuPF29CDiw==}
 
   tldts@6.1.86:
     resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
     hasBin: true
 
-  tldts@7.4.2:
-    resolution: {integrity: sha512-kCwffuaH8ntKtygnWe1b4BJKWiCUH30n5KfoTr6IchcXOwR7chAOFJxFrH3vjANafUYrIA4a7SDL+nn7SiR4Sw==}
+  tldts@7.4.3:
+    resolution: {integrity: sha512-A3BDQBeeukYPzB4QdQ1DtdlUmp4x2OCH8n5UVhEWbyANxNep8GavottKzd1xYKFJKjUgMyPT7EzOfnBO55s8Sg==}
     hasBin: true
 
   tmp@0.2.7:
@@ -5355,8 +5355,8 @@ packages:
     resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
     engines: {node: '>= 0.6'}
 
-  typescript-eslint@8.61.0:
-    resolution: {integrity: sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==}
+  typescript-eslint@8.61.1:
+    resolution: {integrity: sha512-V7PayAfJokV3pEHgN7/v03D1SpujhRfQtYLbLIiBfDDncdg4PAiRBfoS4cnCANK4jmAPncczi59QO3afiXUlNw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     peerDependencies:
       eslint: ^8.57.0 || ^9.0.0 || ^10.0.0
@@ -5376,11 +5376,11 @@ packages:
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
-  undici-types@7.27.2:
-    resolution: {integrity: sha512-cH9f42mHuljpNuoS47sWDDWXVxWnJgYCzHVUlr3tn7+HVx0L6QSO+VG5qgzT4kXkR2K8ZsReaT5bupam6RNAEQ==}
+  undici-types@7.28.0:
+    resolution: {integrity: sha512-LJAfY+2w6HGeT8d8J1wNQsUGUEGio6NWWpwdwurQe4f6oojzCFuGLizl1KSve4irsTxyLly1QhEeE6iapdaIvQ==}
 
-  undici@7.27.2:
-    resolution: {integrity: sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==}
+  undici@7.28.0:
+    resolution: {integrity: sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==}
     engines: {node: '>=20.18.1'}
 
   unicorn-magic@0.3.0:
@@ -5444,8 +5444,8 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0
 
-  vite-plugin-checker@0.14.1:
-    resolution: {integrity: sha512-Mv8oQc9XYBYf+XkP/riqqQCt8lBP6Iad75PZPho1lHRrpxQI0BwX2gwE10enn4f6Hgc+PvR1F7N38KARcaJtzw==}
+  vite-plugin-checker@0.14.4:
+    resolution: {integrity: sha512-Tw0U9UgHIRiZ+Yoe4Gh0RrYoBiCVmO9j4tomVdYr0KUjUsqXMPhqW8ouoSWmOzGp5Iimipbl3bNXZcK7OeP7Qg==}
     engines: {node: '>=20.19.0'}
     peerDependencies:
       '@biomejs/biome': '>=2.4.12'
@@ -5485,8 +5485,8 @@ packages:
       '@nuxt/kit':
         optional: true
 
-  vite-plugin-vue-devtools@8.1.2:
-    resolution: {integrity: sha512-gt5h1CNryR9Hy0tvhSbqY3j0F7aj0pGxBxWLa1lXSiZVkhdWDf0vbCOZyjh8ivFGE6FDHTGy3zkcZGlMZdVHig==}
+  vite-plugin-vue-devtools@8.1.3:
+    resolution: {integrity: sha512-KBTUhbTXvY+GsCdShnCHG4WdijEV74KIDxhF8erfSs5g5mS13g/cPRUf4mLpD10qr5FqHYosNt0j6rP5kpiS1Q==}
     engines: {node: '>=v14.21.3'}
     peerDependencies:
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5539,20 +5539,20 @@ packages:
       yaml:
         optional: true
 
-  vitest@4.1.8:
-    resolution: {integrity: sha512-flY6ScbCIt9HThs+C5HS7jvGOB560DJtk/Z15IQROTA6zEy49Nh8T/dofWTQL+n3vswqn87sbJNiuqw1SDp5Ig==}
+  vitest@4.1.9:
+    resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
       '@opentelemetry/api': ^1.9.0
       '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.8
-      '@vitest/browser-preview': 4.1.8
-      '@vitest/browser-webdriverio': 4.1.8
-      '@vitest/coverage-istanbul': 4.1.8
-      '@vitest/coverage-v8': 4.1.8
-      '@vitest/ui': 4.1.8
+      '@vitest/browser-playwright': 4.1.9
+      '@vitest/browser-preview': 4.1.9
+      '@vitest/browser-webdriverio': 4.1.9
+      '@vitest/coverage-istanbul': 4.1.9
+      '@vitest/coverage-v8': 4.1.9
+      '@vitest/ui': 4.1.9
       happy-dom: '*'
       jsdom: '*'
       vite: ^6.0.0 || ^7.0.0 || ^8.0.0
@@ -5583,8 +5583,8 @@ packages:
   vscode-uri@3.1.0:
     resolution: {integrity: sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==}
 
-  vue-component-type-helpers@3.3.4:
-    resolution: {integrity: sha512-joip1uZTaQR0nD23N400gIdJ7xY+WiiiMA/BCKz842gvGBknqDQAzklUvDEhqFvvrhQY8S2ZANBMu4X70VMFGw==}
+  vue-component-type-helpers@3.3.5:
+    resolution: {integrity: sha512-Fe1jyPJoUGpJOYKOri44jduR7My4yYINOMJISuMAbmrs+L5LbIDUc8NTWZYY3EJLK0yPLuCmcd5zoCsE4k2/KA==}
 
   vue-eslint-parser@10.4.1:
     resolution: {integrity: sha512-Gk6gRDj0n/fkRa3C3l0bBheoBckUq/Rs0F/TvMWIS6nzzx67amAViMe9CkNgsP2tXyQONvGiHQESHwFtZ3aYDA==}
@@ -5610,8 +5610,8 @@ packages:
       vite:
         optional: true
 
-  vue-tsc@3.3.4:
-    resolution: {integrity: sha512-XA/JqmQwS2GZmfgpjOEGdrKwaTSEuPwxpHa7/t6f4yiGrJb3gVHTPb9wBfByMNZwQ+xDXs41b8gaS2DKsOozUw==}
+  vue-tsc@3.3.5:
+    resolution: {integrity: sha512-Rzh/G2MmNlMSAMTiQEjDrsb4dgB/jbtEM47rVN2NtidF1dfb/q4w4QvpQBtW5+y3y5H27Hjh7deVwk+YB02fNg==}
     hasBin: true
     peerDependencies:
       typescript: '>=5.0.0'
@@ -5750,7 +5750,7 @@ snapshots:
     dependencies:
       '@asamuzakjp/generational-cache': 1.0.1
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
-      '@csstools/css-color-parser': 4.1.3(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
+      '@csstools/css-color-parser': 4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
@@ -5802,10 +5802,10 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.31
       jsesc: 3.1.0
 
-  '@babel/generator@8.0.0-rc.6':
+  '@babel/generator@8.0.0':
     dependencies:
-      '@babel/parser': 8.0.0-rc.6
-      '@babel/types': 8.0.0-rc.6
+      '@babel/parser': 8.0.0
+      '@babel/types': 8.0.0
       '@jridgewell/gen-mapping': 0.3.13
       '@jridgewell/trace-mapping': 0.3.31
       '@types/jsesc': 2.5.1
@@ -5885,11 +5885,11 @@ snapshots:
 
   '@babel/helper-string-parser@7.29.7': {}
 
-  '@babel/helper-string-parser@8.0.0-rc.6': {}
+  '@babel/helper-string-parser@8.0.0': {}
 
   '@babel/helper-validator-identifier@7.29.7': {}
 
-  '@babel/helper-validator-identifier@8.0.0-rc.6': {}
+  '@babel/helper-validator-identifier@8.0.2': {}
 
   '@babel/helper-validator-option@7.29.7': {}
 
@@ -5902,9 +5902,9 @@ snapshots:
     dependencies:
       '@babel/types': 7.29.7
 
-  '@babel/parser@8.0.0-rc.6':
+  '@babel/parser@8.0.0':
     dependencies:
-      '@babel/types': 8.0.0-rc.6
+      '@babel/types': 8.0.0
 
   '@babel/plugin-proposal-decorators@7.29.7(@babel/core@7.29.7)':
     dependencies:
@@ -5974,10 +5974,10 @@ snapshots:
       '@babel/helper-string-parser': 7.29.7
       '@babel/helper-validator-identifier': 7.29.7
 
-  '@babel/types@8.0.0-rc.6':
+  '@babel/types@8.0.0':
     dependencies:
-      '@babel/helper-string-parser': 8.0.0-rc.6
-      '@babel/helper-validator-identifier': 8.0.0-rc.6
+      '@babel/helper-string-parser': 8.0.0
+      '@babel/helper-validator-identifier': 8.0.2
 
   '@bramus/specificity@2.4.2':
     dependencies:
@@ -5992,7 +5992,7 @@ snapshots:
       '@csstools/css-parser-algorithms': 4.0.0(@csstools/css-tokenizer@4.0.0)
       '@csstools/css-tokenizer': 4.0.0
 
-  '@csstools/css-color-parser@4.1.3(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
+  '@csstools/css-color-parser@4.1.8(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)':
     dependencies:
       '@csstools/color-helpers': 6.0.2
       '@csstools/css-calc': 3.2.1(@csstools/css-parser-algorithms@4.0.0(@csstools/css-tokenizer@4.0.0))(@csstools/css-tokenizer@4.0.0)
@@ -6017,7 +6017,7 @@ snapshots:
       combined-stream: 1.0.8
       extend: 3.0.2
       forever-agent: 0.6.1
-      form-data: 4.0.5
+      form-data: 4.0.6
       http-signature: 1.4.0
       is-typedarray: 1.0.0
       isstream: 0.1.2
@@ -6286,19 +6286,14 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))':
+  '@eslint-community/eslint-utils@4.9.1(eslint@10.5.0(jiti@2.7.0))':
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
-      eslint-visitor-keys: 3.4.3
-
-  '@eslint-community/eslint-utils@4.9.1(eslint@10.4.1(jiti@2.7.0))':
-    dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.2': {}
 
-  '@eslint/config-array@0.23.5(supports-color@8.1.1)':
+  '@eslint/config-array@0.23.5':
     dependencies:
       '@eslint/object-schema': 3.0.5
       debug: 4.4.3(supports-color@8.1.1)
@@ -6314,9 +6309,9 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/js@10.0.1(eslint@10.4.1(jiti@2.7.0))':
+  '@eslint/js@10.0.1(eslint@10.5.0(jiti@2.7.0))':
     optionalDependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
 
   '@eslint/object-schema@3.0.5': {}
 
@@ -6406,7 +6401,7 @@ snapshots:
 
   '@inquirer/external-editor@3.0.3(@types/node@22.19.21)':
     dependencies:
-      chardet: 2.1.1
+      chardet: 2.2.0
       iconv-lite: 0.7.2
     optionalDependencies:
       '@types/node': 22.19.21
@@ -6698,17 +6693,17 @@ snapshots:
 
   '@pkgr/core@0.3.6': {}
 
-  '@playwright/test@1.60.0':
+  '@playwright/test@1.61.0':
     dependencies:
-      playwright: 1.60.0
+      playwright: 1.61.0
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@quasar/app-vite@2.6.2(@quasar/extras@2.0.1)(@types/node@22.19.21)(eslint@10.4.1(jiti@2.7.0))(jiti@2.7.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.0)(rolldown@1.0.3)(rollup@4.61.1)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)':
+  '@quasar/app-vite@2.6.2(@quasar/extras@2.0.1)(@types/node@22.19.21)(eslint@10.5.0(jiti@2.7.0))(jiti@2.7.0)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.1)(rolldown@1.0.3)(rollup@4.62.2)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(typescript@6.0.3)(vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(vue@3.5.38(typescript@6.0.3))(yaml@2.9.0)':
     dependencies:
       '@quasar/render-ssr-error': 1.0.4
       '@quasar/ssl-certificate': 2.0.0
-      '@quasar/vite-plugin': 1.12.0(@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
+      '@quasar/vite-plugin': 1.12.0(@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
       '@types/chrome': 0.1.43
       '@types/compression': 1.8.1
       '@types/cordova': 11.0.3
@@ -6735,11 +6730,11 @@ snapshots:
       minimist: 1.2.8
       mlly: 1.8.2
       open: 11.0.0
-      quasar: 2.20.0
-      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.3)(rollup@4.61.1)
+      quasar: 2.20.1
+      rollup-plugin-visualizer: 7.0.1(rolldown@1.0.3)(rollup@4.62.2)
       sass-embedded: 1.100.0
-      semver: 7.8.4
-      serialize-javascript: 7.0.5
+      semver: 7.8.5
+      serialize-javascript: 7.0.6
       tinyglobby: 0.2.17
       ts-essentials: 10.2.1(typescript@6.0.3)
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
@@ -6748,7 +6743,7 @@ snapshots:
       webpack-merge: 6.0.1
     optionalDependencies:
       '@quasar/extras': 2.0.1
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
       pinia: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       typescript: 6.0.3
     transitivePeerDependencies:
@@ -6780,10 +6775,10 @@ snapshots:
       fs-extra: 11.3.5
       selfsigned: 5.5.0
 
-  '@quasar/vite-plugin@1.12.0(@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.0)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
+  '@quasar/vite-plugin@1.12.0(@vitejs/plugin-vue@6.0.7(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)))(quasar@2.20.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
     dependencies:
       '@vitejs/plugin-vue': 6.0.7(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))
-      quasar: 2.20.0
+      quasar: 2.20.1
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.38(typescript@6.0.3)
 
@@ -6838,13 +6833,13 @@ snapshots:
 
   '@rolldown/pluginutils@1.0.1': {}
 
-  '@rollup/plugin-alias@6.0.0(rollup@4.61.1)':
+  '@rollup/plugin-alias@6.0.0(rollup@4.62.2)':
     optionalDependencies:
-      rollup: 4.61.1
+      rollup: 4.62.2
 
-  '@rollup/plugin-commonjs@29.0.3(rollup@4.61.1)':
+  '@rollup/plugin-commonjs@29.0.3(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       commondir: 1.0.1
       estree-walker: 2.0.2
       fdir: 6.5.0(picomatch@4.0.4)
@@ -6852,115 +6847,115 @@ snapshots:
       magic-string: 0.30.21
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.61.1
+      rollup: 4.62.2
 
-  '@rollup/plugin-dynamic-import-vars@2.1.5(rollup@4.61.1)':
+  '@rollup/plugin-dynamic-import-vars@2.1.5(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       astring: 1.9.0
       estree-walker: 2.0.2
       fast-glob: 3.3.3
       magic-string: 0.30.21
     optionalDependencies:
-      rollup: 4.61.1
+      rollup: 4.62.2
 
-  '@rollup/plugin-json@6.1.0(rollup@4.61.1)':
+  '@rollup/plugin-json@6.1.0(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
     optionalDependencies:
-      rollup: 4.61.1
+      rollup: 4.62.2
 
-  '@rollup/plugin-node-resolve@16.0.3(rollup@4.61.1)':
+  '@rollup/plugin-node-resolve@16.0.3(rollup@4.62.2)':
     dependencies:
-      '@rollup/pluginutils': 5.4.0(rollup@4.61.1)
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
       '@types/resolve': 1.20.2
       deepmerge: 4.3.1
       is-module: 1.0.0
       resolve: 1.22.12
     optionalDependencies:
-      rollup: 4.61.1
+      rollup: 4.62.2
 
-  '@rollup/pluginutils@5.4.0(rollup@4.61.1)':
+  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
     dependencies:
       '@types/estree': 1.0.9
       estree-walker: 2.0.2
       picomatch: 4.0.4
     optionalDependencies:
-      rollup: 4.61.1
+      rollup: 4.62.2
 
-  '@rollup/rollup-android-arm-eabi@4.61.1':
+  '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
 
-  '@rollup/rollup-android-arm64@4.61.1':
+  '@rollup/rollup-android-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-arm64@4.61.1':
+  '@rollup/rollup-darwin-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-darwin-x64@4.61.1':
+  '@rollup/rollup-darwin-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-arm64@4.61.1':
+  '@rollup/rollup-freebsd-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-freebsd-x64@4.61.1':
+  '@rollup/rollup-freebsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-gnueabihf@4.61.1':
+  '@rollup/rollup-linux-arm-gnueabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm-musleabihf@4.61.1':
+  '@rollup/rollup-linux-arm-musleabihf@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-gnu@4.61.1':
+  '@rollup/rollup-linux-arm64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-arm64-musl@4.61.1':
+  '@rollup/rollup-linux-arm64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-gnu@4.61.1':
+  '@rollup/rollup-linux-loong64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-loong64-musl@4.61.1':
+  '@rollup/rollup-linux-loong64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-gnu@4.61.1':
+  '@rollup/rollup-linux-ppc64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-ppc64-musl@4.61.1':
+  '@rollup/rollup-linux-ppc64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-gnu@4.61.1':
+  '@rollup/rollup-linux-riscv64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-riscv64-musl@4.61.1':
+  '@rollup/rollup-linux-riscv64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-s390x-gnu@4.61.1':
+  '@rollup/rollup-linux-s390x-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-gnu@4.61.1':
+  '@rollup/rollup-linux-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-linux-x64-musl@4.61.1':
+  '@rollup/rollup-linux-x64-musl@4.62.2':
     optional: true
 
-  '@rollup/rollup-openbsd-x64@4.61.1':
+  '@rollup/rollup-openbsd-x64@4.62.2':
     optional: true
 
-  '@rollup/rollup-openharmony-arm64@4.61.1':
+  '@rollup/rollup-openharmony-arm64@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-arm64-msvc@4.61.1':
+  '@rollup/rollup-win32-arm64-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-ia32-msvc@4.61.1':
+  '@rollup/rollup-win32-ia32-msvc@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-gnu@4.61.1':
+  '@rollup/rollup-win32-x64-gnu@4.62.2':
     optional: true
 
-  '@rollup/rollup-win32-x64-msvc@4.61.1':
+  '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
   '@sec-ant/readable-stream@0.4.1': {}
@@ -7036,7 +7031,7 @@ snapshots:
       '@types/node': 22.19.21
       '@types/tough-cookie': 4.0.5
       parse5: 8.0.1
-      undici-types: 7.27.2
+      undici-types: 7.28.0
 
   '@types/jsesc@2.5.1': {}
 
@@ -7073,15 +7068,15 @@ snapshots:
 
   '@types/tough-cookie@4.0.5': {}
 
-  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+  '@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/type-utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
+      eslint: 10.5.0(jiti@2.7.0)
       ignore: 7.0.5
       natural-compare: 1.4.0
       ts-api-utils: 2.5.0(typescript@6.0.3)
@@ -7089,133 +7084,79 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/regexpp': 4.12.2
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/type-utils': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
-      eslint: 10.4.1(jiti@2.7.0)
-      ignore: 7.0.5
-      natural-compare: 1.4.0
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/visitor-keys': 8.61.1
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/project-service@8.61.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/visitor-keys': 8.61.0
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.1(jiti@2.7.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
-
-  '@typescript-eslint/project-service@8.61.0(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
       debug: 4.4.3(supports-color@8.1.1)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/scope-manager@8.61.0':
+  '@typescript-eslint/scope-manager@8.61.1':
     dependencies:
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
 
-  '@typescript-eslint/tsconfig-utils@8.61.0(typescript@6.0.3)':
+  '@typescript-eslint/tsconfig-utils@8.61.1(typescript@6.0.3)':
     dependencies:
       typescript: 6.0.3
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+  '@typescript-eslint/type-utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.5.0(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/type-utils@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
-    dependencies:
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.1(jiti@2.7.0)
-      ts-api-utils: 2.5.0(typescript@6.0.3)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-    optional: true
+  '@typescript-eslint/types@8.61.1': {}
 
-  '@typescript-eslint/types@8.61.0': {}
-
-  '@typescript-eslint/typescript-estree@8.61.0(typescript@6.0.3)':
+  '@typescript-eslint/typescript-estree@8.61.1(typescript@6.0.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/tsconfig-utils': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/visitor-keys': 8.61.0
+      '@typescript-eslint/project-service': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/tsconfig-utils': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/visitor-keys': 8.61.1
       debug: 4.4.3(supports-color@8.1.1)
       minimatch: 10.2.5
-      semver: 7.8.4
+      semver: 7.8.5
       tinyglobby: 0.2.17
       ts-api-utils: 2.5.0(typescript@6.0.3)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)':
+  '@typescript-eslint/utils@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/types': 8.61.1
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)':
+  '@typescript-eslint/visitor-keys@8.61.1':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/types': 8.61.0
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)
-      typescript: 6.0.3
-    transitivePeerDependencies:
-      - supports-color
-
-  '@typescript-eslint/visitor-keys@8.61.0':
-    dependencies:
-      '@typescript-eslint/types': 8.61.0
+      '@typescript-eslint/types': 8.61.1
       eslint-visitor-keys: 5.0.1
 
   '@vitejs/plugin-vue-jsx@5.1.5(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3))':
@@ -7248,56 +7189,56 @@ snapshots:
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vue: 3.5.38(typescript@6.0.3)
 
-  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
+  '@vitest/eslint-plugin@1.6.20(@typescript-eslint/eslint-plugin@8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)(vitest@4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)))':
     dependencies:
-      '@typescript-eslint/scope-manager': 8.61.0
-      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)
+      '@typescript-eslint/scope-manager': 8.61.1
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
     optionalDependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
       typescript: 6.0.3
-      vitest: 4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      vitest: 4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/expect@4.1.8':
+  '@vitest/expect@4.1.9':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.8(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.9(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 4.1.8
+      '@vitest/spy': 4.1.9
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  '@vitest/pretty-format@4.1.8':
+  '@vitest/pretty-format@4.1.9':
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@4.1.8':
+  '@vitest/runner@4.1.9':
     dependencies:
-      '@vitest/utils': 4.1.8
+      '@vitest/utils': 4.1.9
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.8':
+  '@vitest/snapshot@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/utils': 4.1.9
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/spy@4.1.8': {}
+  '@vitest/spy@4.1.9': {}
 
-  '@vitest/utils@4.1.8':
+  '@vitest/utils@4.1.9':
     dependencies:
-      '@vitest/pretty-format': 4.1.8
+      '@vitest/pretty-format': 4.1.9
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
@@ -7415,14 +7356,14 @@ snapshots:
     dependencies:
       '@vue/devtools-kit': 7.7.9
 
-  '@vue/devtools-api@8.1.2':
+  '@vue/devtools-api@8.1.3':
     dependencies:
-      '@vue/devtools-kit': 8.1.2
+      '@vue/devtools-kit': 8.1.3
 
-  '@vue/devtools-core@8.1.2(vue@3.5.38(typescript@6.0.3))':
+  '@vue/devtools-core@8.1.3(vue@3.5.38(typescript@6.0.3))':
     dependencies:
-      '@vue/devtools-kit': 8.1.2
-      '@vue/devtools-shared': 8.1.2
+      '@vue/devtools-kit': 8.1.3
+      '@vue/devtools-shared': 8.1.3
       vue: 3.5.38(typescript@6.0.3)
 
   '@vue/devtools-kit@7.7.9':
@@ -7435,9 +7376,9 @@ snapshots:
       speakingurl: 14.0.1
       superjson: 2.2.6
 
-  '@vue/devtools-kit@8.1.2':
+  '@vue/devtools-kit@8.1.3':
     dependencies:
-      '@vue/devtools-shared': 8.1.2
+      '@vue/devtools-shared': 8.1.3
       birpc: 2.9.0
       hookable: 5.5.3
       perfect-debounce: 2.1.0
@@ -7446,18 +7387,18 @@ snapshots:
     dependencies:
       rfdc: 1.4.1
 
-  '@vue/devtools-shared@8.1.2': {}
+  '@vue/devtools-shared@8.1.3': {}
 
-  '@vue/eslint-config-prettier@10.2.0(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)':
+  '@vue/eslint-config-prettier@10.2.0(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3)':
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
-      eslint-config-prettier: 10.1.8(eslint@10.4.1(jiti@2.7.0))
-      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3)
+      eslint: 10.5.0(jiti@2.7.0)
+      eslint-config-prettier: 10.1.8(eslint@10.5.0(jiti@2.7.0))
+      eslint-plugin-prettier: 5.5.6(eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3)
       prettier: 3.8.3
     transitivePeerDependencies:
       - '@types/eslint'
 
-  '@vue/language-core@3.3.4':
+  '@vue/language-core@3.3.5':
     dependencies:
       '@volar/language-core': 2.4.28
       '@vue/compiler-dom': 3.5.38
@@ -7496,7 +7437,7 @@ snapshots:
       '@vue/compiler-dom': 3.5.38
       js-beautify: 1.15.4
       vue: 3.5.38(typescript@6.0.3)
-      vue-component-type-helpers: 3.3.4
+      vue-component-type-helpers: 3.3.5
     optionalDependencies:
       '@vue/server-renderer': 3.5.38(vue@3.5.38(typescript@6.0.3))
 
@@ -7522,7 +7463,7 @@ snapshots:
 
   acorn@8.17.0: {}
 
-  agent-base@6.0.2(supports-color@8.1.1):
+  agent-base@6.0.2:
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -7629,11 +7570,11 @@ snapshots:
 
   aws4@1.13.2: {}
 
-  axios@1.17.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  axios@1.18.0(debug@4.4.3):
     dependencies:
       follow-redirects: 1.16.0(debug@4.4.3)
-      form-data: 4.0.5
-      https-proxy-agent: 5.0.1(supports-color@8.1.1)
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
@@ -7667,7 +7608,7 @@ snapshots:
   bare-stream@2.13.3(bare-events@2.9.1):
     dependencies:
       b4a: 1.8.1
-      streamx: 2.27.0
+      streamx: 2.28.0
       teex: 1.0.1
     optionalDependencies:
       bare-events: 2.9.1
@@ -7680,7 +7621,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  baseline-browser-mapping@2.10.36: {}
+  baseline-browser-mapping@2.10.38: {}
 
   bcrypt-pbkdf@1.0.2:
     dependencies:
@@ -7731,10 +7672,10 @@ snapshots:
 
   browserslist@4.28.2:
     dependencies:
-      baseline-browser-mapping: 2.10.36
+      baseline-browser-mapping: 2.10.38
       caniuse-lite: 1.0.30001799
-      electron-to-chromium: 1.5.372
-      node-releases: 2.0.47
+      electron-to-chromium: 1.5.376
+      node-releases: 2.0.48
       update-browserslist-db: 1.2.3(browserslist@4.28.2)
 
   buffer-crc32@1.0.0: {}
@@ -7787,7 +7728,7 @@ snapshots:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
 
-  chardet@2.1.1: {}
+  chardet@2.2.0: {}
 
   check-more-types@2.24.0: {}
 
@@ -8065,11 +8006,11 @@ snapshots:
       '@one-ini/wasm': 0.1.1
       commander: 10.0.1
       minimatch: 9.0.9
-      semver: 7.8.4
+      semver: 7.8.5
 
   ee-first@1.1.1: {}
 
-  electron-to-chromium@1.5.372: {}
+  electron-to-chromium@1.5.376: {}
 
   elementtree@0.1.7:
     dependencies:
@@ -8209,76 +8150,63 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-prettier@10.1.8(eslint@10.4.1(jiti@2.7.0)):
+  eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
 
-  eslint-plugin-cypress@6.4.1(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-cypress@6.4.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
       globals: 17.6.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
 
-  eslint-plugin-playwright@2.10.4(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-playwright@2.10.4(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
       globals: 17.6.0
 
-  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.4.1(jiti@2.7.0)))(eslint@10.4.1(jiti@2.7.0))(prettier@3.8.3):
+  eslint-plugin-prettier@5.5.6(eslint-config-prettier@10.1.8(eslint@10.5.0(jiti@2.7.0)))(eslint@10.5.0(jiti@2.7.0))(prettier@3.8.3):
     dependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
       prettier: 3.8.3
       prettier-linter-helpers: 1.0.1
       synckit: 0.11.13
     optionalDependencies:
-      eslint-config-prettier: 10.1.8(eslint@10.4.1(jiti@2.7.0))
+      eslint-config-prettier: 10.1.8(eslint@10.5.0(jiti@2.7.0))
 
-  eslint-plugin-vue@10.0.1(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0))):
+  eslint-plugin-vue@10.0.1(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
-      eslint: 10.4.1(jiti@2.7.0)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      eslint: 10.5.0(jiti@2.7.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 6.1.4
-      semver: 7.8.4
-      vue-eslint-parser: 10.4.1(eslint@10.4.1(jiti@2.7.0))
+      semver: 7.8.5
+      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))
       xml-name-validator: 4.0.0
 
-  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)):
+  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0))):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
+      eslint: 10.5.0(jiti@2.7.0)
       natural-compare: 1.4.0
       nth-check: 2.1.1
       postcss-selector-parser: 7.1.4
-      semver: 7.8.4
-      vue-eslint-parser: 10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
+      semver: 7.8.5
+      vue-eslint-parser: 10.4.1(eslint@10.5.0(jiti@2.7.0))
       xml-name-validator: 4.0.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
 
-  eslint-plugin-vue@10.9.2(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0))):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
-      eslint: 10.4.1(jiti@2.7.0)
-      natural-compare: 1.4.0
-      nth-check: 2.1.1
-      postcss-selector-parser: 7.1.4
-      semver: 7.8.4
-      vue-eslint-parser: 10.4.1(eslint@10.4.1(jiti@2.7.0))
-      xml-name-validator: 4.0.0
-    optionalDependencies:
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3)
-
-  eslint-plugin-yml@3.4.0(eslint@10.4.1(jiti@2.7.0)):
+  eslint-plugin-yml@3.4.0(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
       '@ota-meshi/ast-token-store': 0.3.0
       diff-sequences: 29.6.3
       escape-string-regexp: 5.0.0
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
       natural-compare: 1.4.0
       yaml-eslint-parser: 2.0.0
 
@@ -8293,48 +8221,11 @@ snapshots:
 
   eslint-visitor-keys@5.0.1: {}
 
-  eslint@10.4.1(jiti@2.7.0):
+  eslint@10.5.0(jiti@2.7.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0))
+      '@eslint-community/eslint-utils': 4.9.1(eslint@10.5.0(jiti@2.7.0))
       '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
-      '@eslint/config-helpers': 0.6.0
-      '@eslint/core': 1.2.1
-      '@eslint/plugin-kit': 0.7.2
-      '@humanfs/node': 0.16.8
-      '@humanwhocodes/module-importer': 1.0.1
-      '@humanwhocodes/retry': 0.4.3
-      '@types/estree': 1.0.9
-      ajv: 6.15.0
-      cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
-      escape-string-regexp: 4.0.0
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      esutils: 2.0.3
-      fast-deep-equal: 3.1.3
-      file-entry-cache: 8.0.0
-      find-up: 5.0.0
-      glob-parent: 6.0.2
-      ignore: 5.3.2
-      imurmurhash: 0.1.4
-      is-glob: 4.0.3
-      json-stable-stringify-without-jsonify: 1.0.1
-      minimatch: 10.2.5
-      natural-compare: 1.4.0
-      optionator: 0.9.4
-    optionalDependencies:
-      jiti: 2.7.0
-    transitivePeerDependencies:
-      - supports-color
-
-  eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1):
-    dependencies:
-      '@eslint-community/eslint-utils': 4.9.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))
-      '@eslint-community/regexpp': 4.12.2
-      '@eslint/config-array': 0.23.5(supports-color@8.1.1)
+      '@eslint/config-array': 0.23.5
       '@eslint/config-helpers': 0.6.0
       '@eslint/core': 1.2.1
       '@eslint/plugin-kit': 0.7.2
@@ -8587,7 +8478,7 @@ snapshots:
 
   forever-agent@0.6.1: {}
 
-  form-data@4.0.5:
+  form-data@4.0.6:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
@@ -8737,9 +8628,9 @@ snapshots:
       jsprim: 2.0.2
       sshpk: 1.18.0
 
-  https-proxy-agent@5.0.1(supports-color@8.1.1):
+  https-proxy-agent@5.0.1:
     dependencies:
-      agent-base: 6.0.2(supports-color@8.1.1)
+      agent-base: 6.0.2
       debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
@@ -8871,7 +8762,7 @@ snapshots:
 
   jiti@2.7.0: {}
 
-  joi@18.2.1:
+  joi@18.2.3:
     dependencies:
       '@hapi/address': 5.1.1
       '@hapi/formula': 3.0.2
@@ -8912,7 +8803,7 @@ snapshots:
       saxes: 6.0.0
       symbol-tree: 3.2.4
       tough-cookie: 6.0.1
-      undici: 7.27.2
+      undici: 7.28.0
       w3c-xmlserializer: 5.0.0
       webidl-conversions: 8.0.1
       whatwg-mimetype: 5.0.0
@@ -9144,7 +9035,7 @@ snapshots:
 
   mute-stream@3.0.0: {}
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.13: {}
 
   natural-compare@1.4.0: {}
 
@@ -9160,7 +9051,7 @@ snapshots:
   node-addon-api@7.1.1:
     optional: true
 
-  node-releases@2.0.47: {}
+  node-releases@2.0.48: {}
 
   nopt@7.2.1:
     dependencies:
@@ -9170,13 +9061,13 @@ snapshots:
 
   npm-normalize-package-bin@6.0.0: {}
 
-  npm-run-all2@9.0.1:
+  npm-run-all2@9.0.2:
     dependencies:
       ansi-styles: 6.2.3
       cross-spawn: 7.0.6
       memorystream: 0.3.1
       picomatch: 4.0.4
-      pidtree: 0.6.1
+      pidtree: 1.0.0
       read-package-json-fast: 6.0.0
       shell-quote: 1.8.4
       which: 7.0.0
@@ -9299,7 +9190,7 @@ snapshots:
 
   picomatch@4.0.4: {}
 
-  pidtree@0.6.1: {}
+  pidtree@1.0.0: {}
 
   pify@2.3.0: {}
 
@@ -9324,16 +9215,16 @@ snapshots:
 
   pkgroll@2.27.1(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@rollup/plugin-alias': 6.0.0(rollup@4.61.1)
-      '@rollup/plugin-commonjs': 29.0.3(rollup@4.61.1)
-      '@rollup/plugin-dynamic-import-vars': 2.1.5(rollup@4.61.1)
-      '@rollup/plugin-json': 6.1.0(rollup@4.61.1)
-      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.61.1)
+      '@rollup/plugin-alias': 6.0.0(rollup@4.62.2)
+      '@rollup/plugin-commonjs': 29.0.3(rollup@4.62.2)
+      '@rollup/plugin-dynamic-import-vars': 2.1.5(rollup@4.62.2)
+      '@rollup/plugin-json': 6.1.0(rollup@4.62.2)
+      '@rollup/plugin-node-resolve': 16.0.3(rollup@4.62.2)
       cjs-module-lexer: 2.2.0
       esbuild: 0.26.0
       magic-string: 0.30.21
-      rollup: 4.61.1
-      rollup-plugin-import-trace: 1.0.1(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      rollup: 4.62.2
+      rollup-plugin-import-trace: 1.0.1(rollup@4.62.2)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       rollup-pluginutils: 2.8.2
       yaml: 2.9.0
     optionalDependencies:
@@ -9350,11 +9241,11 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.60.0: {}
+  playwright-core@1.61.0: {}
 
-  playwright@1.60.0:
+  playwright@1.61.0:
     dependencies:
-      playwright-core: 1.60.0
+      playwright-core: 1.61.0
     optionalDependencies:
       fsevents: 2.3.2
 
@@ -9372,7 +9263,7 @@ snapshots:
 
   postcss@8.5.15:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.13
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
@@ -9432,7 +9323,7 @@ snapshots:
 
   quansync@0.2.11: {}
 
-  quasar@2.20.0: {}
+  quasar@2.20.1: {}
 
   queue-microtask@1.2.3: {}
 
@@ -9523,12 +9414,12 @@ snapshots:
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
 
-  rollup-plugin-import-trace@1.0.1(rollup@4.61.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  rollup-plugin-import-trace@1.0.1(rollup@4.62.2)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     optionalDependencies:
-      rollup: 4.61.1
+      rollup: 4.62.2
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.61.1):
+  rollup-plugin-visualizer@7.0.1(rolldown@1.0.3)(rollup@4.62.2):
     dependencies:
       open: 11.0.0
       picomatch: 4.0.4
@@ -9536,41 +9427,41 @@ snapshots:
       yargs: 18.0.0
     optionalDependencies:
       rolldown: 1.0.3
-      rollup: 4.61.1
+      rollup: 4.62.2
 
   rollup-pluginutils@2.8.2:
     dependencies:
       estree-walker: 0.6.1
 
-  rollup@4.61.1:
+  rollup@4.62.2:
     dependencies:
       '@types/estree': 1.0.9
     optionalDependencies:
-      '@rollup/rollup-android-arm-eabi': 4.61.1
-      '@rollup/rollup-android-arm64': 4.61.1
-      '@rollup/rollup-darwin-arm64': 4.61.1
-      '@rollup/rollup-darwin-x64': 4.61.1
-      '@rollup/rollup-freebsd-arm64': 4.61.1
-      '@rollup/rollup-freebsd-x64': 4.61.1
-      '@rollup/rollup-linux-arm-gnueabihf': 4.61.1
-      '@rollup/rollup-linux-arm-musleabihf': 4.61.1
-      '@rollup/rollup-linux-arm64-gnu': 4.61.1
-      '@rollup/rollup-linux-arm64-musl': 4.61.1
-      '@rollup/rollup-linux-loong64-gnu': 4.61.1
-      '@rollup/rollup-linux-loong64-musl': 4.61.1
-      '@rollup/rollup-linux-ppc64-gnu': 4.61.1
-      '@rollup/rollup-linux-ppc64-musl': 4.61.1
-      '@rollup/rollup-linux-riscv64-gnu': 4.61.1
-      '@rollup/rollup-linux-riscv64-musl': 4.61.1
-      '@rollup/rollup-linux-s390x-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-gnu': 4.61.1
-      '@rollup/rollup-linux-x64-musl': 4.61.1
-      '@rollup/rollup-openbsd-x64': 4.61.1
-      '@rollup/rollup-openharmony-arm64': 4.61.1
-      '@rollup/rollup-win32-arm64-msvc': 4.61.1
-      '@rollup/rollup-win32-ia32-msvc': 4.61.1
-      '@rollup/rollup-win32-x64-gnu': 4.61.1
-      '@rollup/rollup-win32-x64-msvc': 4.61.1
+      '@rollup/rollup-android-arm-eabi': 4.62.2
+      '@rollup/rollup-android-arm64': 4.62.2
+      '@rollup/rollup-darwin-arm64': 4.62.2
+      '@rollup/rollup-darwin-x64': 4.62.2
+      '@rollup/rollup-freebsd-arm64': 4.62.2
+      '@rollup/rollup-freebsd-x64': 4.62.2
+      '@rollup/rollup-linux-arm-gnueabihf': 4.62.2
+      '@rollup/rollup-linux-arm-musleabihf': 4.62.2
+      '@rollup/rollup-linux-arm64-gnu': 4.62.2
+      '@rollup/rollup-linux-arm64-musl': 4.62.2
+      '@rollup/rollup-linux-loong64-gnu': 4.62.2
+      '@rollup/rollup-linux-loong64-musl': 4.62.2
+      '@rollup/rollup-linux-ppc64-gnu': 4.62.2
+      '@rollup/rollup-linux-ppc64-musl': 4.62.2
+      '@rollup/rollup-linux-riscv64-gnu': 4.62.2
+      '@rollup/rollup-linux-riscv64-musl': 4.62.2
+      '@rollup/rollup-linux-s390x-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-gnu': 4.62.2
+      '@rollup/rollup-linux-x64-musl': 4.62.2
+      '@rollup/rollup-openbsd-x64': 4.62.2
+      '@rollup/rollup-openharmony-arm64': 4.62.2
+      '@rollup/rollup-win32-arm64-msvc': 4.62.2
+      '@rollup/rollup-win32-ia32-msvc': 4.62.2
+      '@rollup/rollup-win32-x64-gnu': 4.62.2
+      '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
   run-applescript@7.1.0: {}
@@ -9702,7 +9593,7 @@ snapshots:
 
   semver@6.3.1: {}
 
-  semver@7.8.4: {}
+  semver@7.8.5: {}
 
   send@0.19.2:
     dependencies:
@@ -9722,7 +9613,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serialize-javascript@7.0.5: {}
+  serialize-javascript@7.0.6: {}
 
   serve-static@1.16.3:
     dependencies:
@@ -9826,7 +9717,7 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  start-server-and-test@3.0.11(supports-color@8.1.1):
+  start-server-and-test@3.0.11:
     dependencies:
       arg: 5.0.2
       check-more-types: 2.24.0
@@ -9834,7 +9725,7 @@ snapshots:
       execa: 5.1.1
       lazy-ass: 2.0.3
       tree-kill: 1.2.2
-      wait-on: 9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
+      wait-on: 9.0.10(debug@4.4.3)
     transitivePeerDependencies:
       - supports-color
 
@@ -9842,7 +9733,7 @@ snapshots:
 
   std-env@4.1.0: {}
 
-  streamx@2.27.0:
+  streamx@2.28.0:
     dependencies:
       events-universal: 1.0.1
       fast-fifo: 1.3.2
@@ -9929,7 +9820,7 @@ snapshots:
       b4a: 1.8.1
       bare-fs: 4.7.2
       fast-fifo: 1.3.2
-      streamx: 2.27.0
+      streamx: 2.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - bare-buffer
@@ -9937,7 +9828,7 @@ snapshots:
 
   teex@1.0.1:
     dependencies:
-      streamx: 2.27.0
+      streamx: 2.28.0
     transitivePeerDependencies:
       - bare-abort-controller
       - react-native-b4a
@@ -9972,15 +9863,15 @@ snapshots:
 
   tldts-core@6.1.86: {}
 
-  tldts-core@7.4.2: {}
+  tldts-core@7.4.3: {}
 
   tldts@6.1.86:
     dependencies:
       tldts-core: 6.1.86
 
-  tldts@7.4.2:
+  tldts@7.4.3:
     dependencies:
-      tldts-core: 7.4.2
+      tldts-core: 7.4.3
 
   tmp@0.2.7: {}
 
@@ -9998,7 +9889,7 @@ snapshots:
 
   tough-cookie@6.0.1:
     dependencies:
-      tldts: 7.4.2
+      tldts: 7.4.3
 
   tr46@6.0.0:
     dependencies:
@@ -10049,13 +9940,13 @@ snapshots:
       media-typer: 0.3.0
       mime-types: 2.1.35
 
-  typescript-eslint@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3):
+  typescript-eslint@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.61.0(@typescript-eslint/parser@8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      '@typescript-eslint/parser': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      '@typescript-eslint/typescript-estree': 8.61.0(typescript@6.0.3)
-      '@typescript-eslint/utils': 8.61.0(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(typescript@6.0.3)
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      '@typescript-eslint/eslint-plugin': 8.61.1(@typescript-eslint/parser@8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/parser': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      '@typescript-eslint/typescript-estree': 8.61.1(typescript@6.0.3)
+      '@typescript-eslint/utils': 8.61.1(eslint@10.5.0(jiti@2.7.0))(typescript@6.0.3)
+      eslint: 10.5.0(jiti@2.7.0)
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
@@ -10068,9 +9959,9 @@ snapshots:
 
   undici-types@7.18.2: {}
 
-  undici-types@7.27.2: {}
+  undici-types@7.28.0: {}
 
-  undici@7.27.2: {}
+  undici@7.28.0: {}
 
   unicorn-magic@0.3.0: {}
 
@@ -10135,7 +10026,7 @@ snapshots:
     dependencies:
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vite-plugin-checker@0.14.1(eslint@10.4.1(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.4(typescript@6.0.3)):
+  vite-plugin-checker@0.14.4(eslint@10.5.0(jiti@2.7.0))(optionator@0.9.4)(typescript@6.0.3)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue-tsc@3.3.5(typescript@6.0.3)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chokidar: 5.0.0
@@ -10146,10 +10037,10 @@ snapshots:
       tiny-invariant: 1.3.3
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
     optionalDependencies:
-      eslint: 10.4.1(jiti@2.7.0)
+      eslint: 10.5.0(jiti@2.7.0)
       optionator: 0.9.4
       typescript: 6.0.3
-      vue-tsc: 3.3.4(typescript@6.0.3)
+      vue-tsc: 3.3.5(typescript@6.0.3)
 
   vite-plugin-inspect@11.4.1(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
@@ -10177,11 +10068,11 @@ snapshots:
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-dev-rpc: 2.0.0(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
 
-  vite-plugin-vue-devtools@8.1.2(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
+  vite-plugin-vue-devtools@8.1.3(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
-      '@vue/devtools-core': 8.1.2(vue@3.5.38(typescript@6.0.3))
-      '@vue/devtools-kit': 8.1.2
-      '@vue/devtools-shared': 8.1.2
+      '@vue/devtools-core': 8.1.3(vue@3.5.38(typescript@6.0.3))
+      '@vue/devtools-kit': 8.1.3
+      '@vue/devtools-shared': 8.1.3
       sirv: 3.0.2
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -10191,11 +10082,11 @@ snapshots:
       - supports-color
       - vue
 
-  vite-plugin-vue-devtools@8.1.2(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
+  vite-plugin-vue-devtools@8.1.3(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
-      '@vue/devtools-core': 8.1.2(vue@3.5.38(typescript@6.0.3))
-      '@vue/devtools-kit': 8.1.2
-      '@vue/devtools-shared': 8.1.2
+      '@vue/devtools-core': 8.1.3(vue@3.5.38(typescript@6.0.3))
+      '@vue/devtools-kit': 8.1.3
+      '@vue/devtools-shared': 8.1.3
       sirv: 3.0.2
       vite: 8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
       vite-plugin-inspect: 11.4.1(vite@8.0.16(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
@@ -10289,15 +10180,15 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.9(@types/node@22.19.21)(jsdom@29.1.1)(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
+      '@vitest/expect': 4.1.9
+      '@vitest/mocker': 4.1.9(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.9
+      '@vitest/runner': 4.1.9
+      '@vitest/snapshot': 4.1.9
+      '@vitest/spy': 4.1.9
+      '@vitest/utils': 4.1.9
       es-module-lexer: 2.1.0
       expect-type: 1.3.0
       magic-string: 0.30.21
@@ -10319,37 +10210,25 @@ snapshots:
 
   vscode-uri@3.1.0: {}
 
-  vue-component-type-helpers@3.3.4: {}
+  vue-component-type-helpers@3.3.5: {}
 
-  vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1):
+  vue-eslint-parser@10.4.1(eslint@10.5.0(jiti@2.7.0)):
     dependencies:
       debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.1(jiti@2.7.0)(supports-color@8.1.1)
+      eslint: 10.5.0(jiti@2.7.0)
       eslint-scope: 9.1.2
       eslint-visitor-keys: 5.0.1
       espree: 11.2.0
       esquery: 1.7.0
-      semver: 7.8.4
-    transitivePeerDependencies:
-      - supports-color
-
-  vue-eslint-parser@10.4.1(eslint@10.4.1(jiti@2.7.0)):
-    dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
-      eslint: 10.4.1(jiti@2.7.0)
-      eslint-scope: 9.1.2
-      eslint-visitor-keys: 5.0.1
-      espree: 11.2.0
-      esquery: 1.7.0
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - supports-color
 
   vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.27.7)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
-      '@babel/generator': 8.0.0-rc.6
+      '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@6.0.3))
-      '@vue/devtools-api': 8.1.2
+      '@vue/devtools-api': 8.1.3
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
       json5: 2.2.3
@@ -10372,9 +10251,9 @@ snapshots:
 
   vue-router@5.1.0(@vue/compiler-sfc@3.5.38)(pinia@3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3)))(vite@8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))(vue@3.5.38(typescript@6.0.3)):
     dependencies:
-      '@babel/generator': 8.0.0-rc.6
+      '@babel/generator': 8.0.0
       '@vue-macros/common': 3.1.2(vue@3.5.38(typescript@6.0.3))
-      '@vue/devtools-api': 8.1.2
+      '@vue/devtools-api': 8.1.3
       ast-walker-scope: 0.9.0
       chokidar: 5.0.0
       json5: 2.2.3
@@ -10395,10 +10274,10 @@ snapshots:
       pinia: 3.0.4(typescript@6.0.3)(vue@3.5.38(typescript@6.0.3))
       vite: 8.0.16(@types/node@22.19.21)(esbuild@0.28.1)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
-  vue-tsc@3.3.4(typescript@6.0.3):
+  vue-tsc@3.3.5(typescript@6.0.3):
     dependencies:
       '@volar/typescript': 2.4.28
-      '@vue/language-core': 3.3.4
+      '@vue/language-core': 3.3.5
       typescript: 6.0.3
 
   vue@3.5.38(typescript@6.0.3):
@@ -10415,10 +10294,10 @@ snapshots:
     dependencies:
       xml-name-validator: 5.0.0
 
-  wait-on@9.0.10(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1):
+  wait-on@9.0.10(debug@4.4.3):
     dependencies:
-      axios: 1.17.0(debug@4.4.3(supports-color@8.1.1))(supports-color@8.1.1)
-      joi: 18.2.1
+      axios: 1.18.0(debug@4.4.3)
+      joi: 18.2.3
       lodash: 4.18.1
       minimist: 1.2.8
       rxjs: 7.8.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1071,6 +1071,25 @@ importers:
         specifier: ^3.3.2
         version: 3.3.3(typescript@6.0.3)
 
+  test/fixtures/with-vue-ts-api:
+    dependencies:
+      vue:
+        specifier: ^3.5.35
+        version: 3.5.35(typescript@6.0.3)
+    devDependencies:
+      '@vue/eslint-config-typescript':
+        specifier: workspace:*
+        version: link:../../..
+      eslint:
+        specifier: ^10.4.0
+        version: 10.4.1(jiti@2.7.0)
+      eslint-plugin-vue:
+        specifier: ~10.9.1
+        version: 10.9.1(@typescript-eslint/parser@8.60.1(eslint@10.4.1(jiti@2.7.0))(typescript@6.0.3))(eslint@10.4.1(jiti@2.7.0))(vue-eslint-parser@10.4.0(eslint@10.4.1(jiti@2.7.0)))
+      typescript:
+        specifier: ~6.0.0
+        version: 6.0.3
+
 packages:
 
   '@asamuzakjp/css-color@5.1.11':

--- a/src/bin.ts
+++ b/src/bin.ts
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+import process from 'node:process'
+
+import { runMigrateToWithVueTsCommand } from './commands/migrateToWithVueTs'
+
+const COMMANDS = {
+  'migrate-to-with-vue-ts': runMigrateToWithVueTsCommand,
+  'migrate-14.9': runMigrateToWithVueTsCommand,
+} as const
+
+function printHelp(): void {
+  console.log(`Usage:
+  vue-eslint-config-typescript <command> [args]
+
+Commands:
+  migrate-to-with-vue-ts   Primary command. Migrate legacy helper-based configs to withVueTs(...)
+  migrate-14.9             Versioned alias for migrate-to-with-vue-ts
+`)
+}
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2)
+
+  if (!command || command === '--help' || command === '-h') {
+    printHelp()
+    return
+  }
+
+  const runCommand = COMMANDS[command as keyof typeof COMMANDS]
+  if (!runCommand) {
+    console.error(`Unknown command: ${command}\n`)
+    printHelp()
+    process.exitCode = 1
+    return
+  }
+
+  await runCommand(args)
+}
+
+main().catch((error: unknown) => {
+  const message =
+    error instanceof Error ? (error.stack ?? error.message) : String(error)
+  console.error(message)
+  process.exitCode = 1
+})

--- a/src/commands/migrateToWithVueTs.ts
+++ b/src/commands/migrateToWithVueTs.ts
@@ -1,0 +1,228 @@
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import process from 'node:process'
+import { createInterface } from 'node:readline/promises'
+
+import fg from 'fast-glob'
+
+import {
+  analyzeToWithVueTsMigrationText,
+  applyToWithVueTsMigrationText,
+} from '../migrations/toWithVueTs'
+
+type CliOptions = {
+  yes: boolean
+  help: boolean
+  patterns: string[]
+}
+
+type MigrationCandidate = {
+  filename: string
+  relativeFilename: string
+  analysis: ReturnType<typeof analyzeToWithVueTsMigrationText>
+}
+
+const DEFAULT_PATTERNS = ['**/eslint.config.{js,mjs,ts,mts}']
+const DEFAULT_IGNORE = ['**/node_modules/**', '**/.git/**', '**/dist/**']
+
+function isFixableCandidate(
+  candidate: MigrationCandidate,
+): candidate is MigrationCandidate & {
+  analysis: Extract<MigrationCandidate['analysis'], { status: 'fixable' }>
+} {
+  return candidate.analysis.status === 'fixable'
+}
+
+function isUnsupportedCandidate(
+  candidate: MigrationCandidate,
+): candidate is MigrationCandidate & {
+  analysis: Extract<
+    MigrationCandidate['analysis'],
+    { status: 'unsupported' } | { status: 'parse-error' }
+  >
+} {
+  return (
+    candidate.analysis.status === 'unsupported' ||
+    candidate.analysis.status === 'parse-error'
+  )
+}
+
+function parseArgs(argv: string[]): CliOptions {
+  return {
+    yes: argv.includes('--yes') || argv.includes('-y'),
+    help: argv.includes('--help') || argv.includes('-h'),
+    patterns: argv.filter(
+      arg => !['--yes', '-y', '--help', '-h'].includes(arg),
+    ),
+  }
+}
+
+function printHelp(): void {
+  console.log(`Usage:
+  vue-eslint-config-typescript migrate-to-with-vue-ts [paths...] [--yes]
+
+Examples:
+  npx @vue/eslint-config-typescript migrate-to-with-vue-ts
+  npx @vue/eslint-config-typescript migrate-to-with-vue-ts eslint.config.ts
+  npx @vue/eslint-config-typescript migrate-to-with-vue-ts "packages/*/eslint.config.ts" --yes
+`)
+}
+
+async function resolveTargetFiles(patterns: string[]): Promise<string[]> {
+  const targetPatterns = patterns.length > 0 ? patterns : DEFAULT_PATTERNS
+  const explicitFiles: string[] = []
+  const globPatterns: string[] = []
+
+  for (const pattern of targetPatterns) {
+    const filename = path.resolve(pattern)
+    const stat = await fs.stat(filename).catch(() => undefined)
+    if (stat?.isFile()) {
+      explicitFiles.push(filename)
+      continue
+    }
+
+    globPatterns.push(pattern)
+  }
+
+  const entries = await fg(globPatterns, {
+    cwd: process.cwd(),
+    absolute: true,
+    onlyFiles: true,
+    unique: true,
+    ignore: DEFAULT_IGNORE,
+  })
+
+  return [...new Set([...explicitFiles, ...entries])].sort()
+}
+
+async function loadCandidates(
+  filenames: string[],
+): Promise<MigrationCandidate[]> {
+  return Promise.all(
+    filenames.map(async filename => {
+      const text = await fs.readFile(filename, 'utf8')
+      return {
+        filename,
+        relativeFilename:
+          path.relative(process.cwd(), filename) || path.basename(filename),
+        analysis: analyzeToWithVueTsMigrationText(text, filename),
+      }
+    }),
+  )
+}
+
+function printSummary(candidates: MigrationCandidate[]): void {
+  const fixable = candidates.filter(isFixableCandidate)
+  const unsupported = candidates.filter(isUnsupportedCandidate)
+
+  console.log(`Found ${candidates.length} ESLint config file(s).\n`)
+
+  if (fixable.length > 0) {
+    console.log('Auto-migratable:')
+    for (const candidate of fixable) {
+      console.log(`- ${candidate.relativeFilename}`)
+      for (const change of candidate.analysis.changes) {
+        console.log(`  - ${change}`)
+      }
+    }
+    console.log('')
+  }
+
+  if (unsupported.length > 0) {
+    console.log('Needs manual review:')
+    for (const candidate of unsupported) {
+      console.log(`- ${candidate.relativeFilename}`)
+      if (candidate.analysis.status === 'parse-error') {
+        console.log(`  - parser error: ${candidate.analysis.reason}`)
+        continue
+      }
+
+      for (const reason of candidate.analysis.reasons) {
+        console.log(`  - ${reason}`)
+      }
+    }
+    console.log('')
+  }
+
+  if (fixable.length === 0 && unsupported.length === 0) {
+    console.log('No migration needed.\n')
+  }
+}
+
+async function confirmApply(): Promise<boolean> {
+  const readline = createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  })
+
+  try {
+    const answer = (await readline.question('Apply automatic changes? [Y/n] '))
+      .trim()
+      .toLowerCase()
+
+    return answer === '' || answer === 'y' || answer === 'yes'
+  } finally {
+    readline.close()
+  }
+}
+
+async function applyFixes(candidates: MigrationCandidate[]): Promise<number> {
+  let updatedFiles = 0
+
+  for (const candidate of candidates) {
+    if (candidate.analysis.status !== 'fixable') {
+      continue
+    }
+
+    const input = await fs.readFile(candidate.filename, 'utf8')
+    const result = applyToWithVueTsMigrationText(input, candidate.filename)
+    if (!result.changed) {
+      continue
+    }
+
+    await fs.writeFile(candidate.filename, result.output)
+    updatedFiles += 1
+  }
+
+  return updatedFiles
+}
+
+export async function runMigrateToWithVueTsCommand(
+  argv: string[],
+): Promise<void> {
+  const options = parseArgs(argv)
+  if (options.help) {
+    printHelp()
+    return
+  }
+
+  const filenames = await resolveTargetFiles(options.patterns)
+  if (filenames.length === 0) {
+    console.log('No matching ESLint config files found.')
+    return
+  }
+
+  const candidates = await loadCandidates(filenames)
+  printSummary(candidates)
+
+  const fixableCount = candidates.filter(isFixableCandidate).length
+  if (fixableCount === 0) {
+    return
+  }
+
+  if (!options.yes && !process.stdin.isTTY) {
+    console.log(
+      'Cannot prompt in a non-interactive terminal. Re-run with `--yes` to apply the automatic changes.',
+    )
+    return
+  }
+
+  const shouldApply = options.yes ? true : await confirmApply()
+  if (!shouldApply) {
+    console.log('No files were changed.')
+    return
+  }
+
+  const updatedFiles = await applyFixes(candidates)
+  console.log(`Updated ${updatedFiles} file(s).`)
+}

--- a/src/configs.ts
+++ b/src/configs.ts
@@ -22,85 +22,126 @@ function toArray<T>(value: T | T[]): T[] {
   return Array.isArray(value) ? value : [value]
 }
 
-/**
- * The options that a config in the `extends` should inherit.
- */
-type ExtendsOptions = {
+const VUE_TS_CONFIG = Symbol('@vue/eslint-config-typescript/vue-ts-config')
+const TS_FILES_GLOB = '**/*.ts'
+const VUE_FILES_GLOB = '**/*.vue'
+
+type VueTsConfigMeta = {
+  configName: ExtendableConfigName
+  needsTypeChecking: boolean
+}
+
+export type VueTsConfig = FlatConfig.Config & {
+  [VUE_TS_CONFIG]: VueTsConfigMeta
+}
+
+export type ExtendConfigOptions = {
   name?: string
   files?: (string | string[])[]
   ignores?: string[]
 }
 
-export class TsEslintConfigForVue {
-  /**
-   * The name of the config object as defined in `typescript-eslint`.
-   */
-  configName: ExtendableConfigName
-
-  /**
-   * the name property is here to provide better error messages when ESLint throws an error
-   */
-  name: string
-
-  constructor(configName: ExtendableConfigName) {
-    this.configName = configName
-    this.name = `vueTsConfigs.${configName}`
+function needsTypeChecking(configName: ExtendableConfigName): boolean {
+  if (configName === 'disableTypeChecked') {
+    return false
   }
-
-  extendsOptions?: ExtendsOptions
-  /**
-   * Create a new instance of `TsEslintConfigForVue` with the `restOfConfig` merged into it.
-   * Should be used when the config is used in the `extends` field of another config.
-   */
-  asExtendedWith(restOfConfig: ExtendsOptions): TsEslintConfigForVue {
-    const extendedConfig = new TsEslintConfigForVue(this.configName)
-
-    extendedConfig.extendsOptions = {
-      name: [restOfConfig.name, this.name].filter(Boolean).join('__'),
-      ...(restOfConfig.files && { files: restOfConfig.files }),
-      ...(restOfConfig.ignores && { ignores: restOfConfig.ignores }),
-    }
-
-    return extendedConfig
+  if (configName === 'all') {
+    return true
   }
+  return configName.includes('TypeChecked')
+}
 
-  needsTypeChecking(): boolean {
-    if (this.configName === 'disableTypeChecked') {
-      return false
-    }
-    if (this.configName === 'all') {
-      return true
-    }
-    return this.configName.includes('TypeChecked')
+function markVueTsConfig(
+  config: FlatConfig.Config,
+  meta: VueTsConfigMeta,
+): VueTsConfig {
+  return {
+    ...config,
+    [VUE_TS_CONFIG]: meta,
   }
+}
 
-  toConfigArray(): FlatConfig.ConfigArray {
-    return toArray(tseslint.configs[this.configName])
-      .flat()
-      .map((config: FlatConfig.Config) => ({
-        ...config,
-        ...(config.files && config.files.includes('**/*.ts')
-          ? { files: [...config.files, '**/*.vue'] }
-          : {}),
-        ...this.extendsOptions,
-      }))
+function createVueTsConfig(
+  configName: ExtendableConfigName,
+): FlatConfig.ConfigArray {
+  const meta = {
+    configName,
+    needsTypeChecking: needsTypeChecking(configName),
+  } satisfies VueTsConfigMeta
+
+  return toArray(tseslint.configs[configName])
+    .flat()
+    .map((config: FlatConfig.Config) => markVueTsConfig(config, meta))
+}
+
+function hasTsMatcher(files: (string | string[])[]): boolean {
+  return files.some(fileMatcher =>
+    Array.isArray(fileMatcher)
+      ? fileMatcher.includes(TS_FILES_GLOB)
+      : fileMatcher === TS_FILES_GLOB,
+  )
+}
+
+function addVueMatcher(files: (string | string[])[]): (string | string[])[] {
+  const vueMatchers = files.reduce<(string | string[])[]>(
+    (result, fileMatcher) => {
+      if (Array.isArray(fileMatcher)) {
+        if (fileMatcher.includes(TS_FILES_GLOB)) {
+          result.push(
+            fileMatcher.map(matcher =>
+              matcher === TS_FILES_GLOB ? VUE_FILES_GLOB : matcher,
+            ),
+          )
+        }
+        return result
+      }
+
+      if (fileMatcher === TS_FILES_GLOB) {
+        result.push(VUE_FILES_GLOB)
+      }
+      return result
+    },
+    [],
+  )
+
+  return vueMatchers.length > 0 ? [...files, ...vueMatchers] : files
+}
+
+export function isVueTsConfig(
+  config: FlatConfig.Config,
+): config is VueTsConfig {
+  return VUE_TS_CONFIG in config
+}
+
+export function extendVueTsConfig(
+  config: VueTsConfig,
+  restOfConfig: ExtendConfigOptions,
+): VueTsConfig {
+  const name = [restOfConfig.name, config.name].filter(Boolean).join('__')
+
+  return {
+    ...config,
+    ...(restOfConfig.files && { files: restOfConfig.files }),
+    ...(restOfConfig.ignores && { ignores: restOfConfig.ignores }),
+    ...(name && { name }),
+  }
+}
+
+export function vueTsConfigNeedsTypeChecking(config: VueTsConfig): boolean {
+  return config[VUE_TS_CONFIG].needsTypeChecking
+}
+
+export function resolveVueTsConfig(config: VueTsConfig): FlatConfig.Config {
+  const { [VUE_TS_CONFIG]: _meta, ...resolvedConfig } = config
+
+  return {
+    ...resolvedConfig,
+    ...(resolvedConfig.files && hasTsMatcher(resolvedConfig.files)
+      ? { files: addVueMatcher(resolvedConfig.files) }
+      : {}),
   }
 }
 
 export const vueTsConfigs = Object.fromEntries(
-  CONFIG_NAMES.map(name => [
-    name,
-    new Proxy(new TsEslintConfigForVue(name), {
-      // `ownKeys` is called by ESLint when validating the config object.
-      // The only possible scenario where this is called is when the placeholder object
-      // isn't replaced, which means it's passed to ESLint without being wrapped by
-      // `defineConfigWithVueTs()`
-      // We throw an error here to provide a better error message to the user.
-      ownKeys() {
-        throw new Error(
-          'Please wrap the config object with `defineConfigWithVueTs()`',
-        )
-      },
-    }),
-  ]),
-) as Record<ExtendableConfigName, TsEslintConfigForVue>
+  CONFIG_NAMES.map(name => [name, createVueTsConfig(name)]),
+) as Record<ExtendableConfigName, FlatConfig.Config | FlatConfig.ConfigArray>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,8 @@
-export { defineConfigWithVueTs, configureVueProject } from './utilities'
+export {
+  defineConfigWithVueTs,
+  withVueTs,
+  configureVueProject,
+} from './utilities'
 export { vueTsConfigs } from './configs'
 
 // Compatibility layer for the `createConfig` function in <= 14.2.0

--- a/src/migrations/astHelpers.ts
+++ b/src/migrations/astHelpers.ts
@@ -1,0 +1,170 @@
+import type { SourceCode } from 'eslint'
+
+export type ImportDeclarationNode = SourceCode['ast']['body'][number] & {
+  type: 'ImportDeclaration'
+}
+
+export type ExpressionStatementNode = SourceCode['ast']['body'][number] & {
+  type: 'ExpressionStatement'
+}
+
+export type ExportDefaultDeclarationNode = SourceCode['ast']['body'][number] & {
+  type: 'ExportDefaultDeclaration'
+}
+
+export type CallExpressionNode = {
+  type: 'CallExpression'
+  callee: unknown
+  arguments: unknown[]
+  range: [number, number]
+}
+
+export type GenericAstNode = {
+  type: string
+  [key: string]: unknown
+  range?: [number, number]
+}
+
+export type IdentifierNode = GenericAstNode & {
+  type: 'Identifier'
+  name: string
+}
+
+export type IdentifierUsage = {
+  identifier: IdentifierNode
+  parent: GenericAstNode | null
+}
+
+export type ImportSpecifierNode = ImportDeclarationNode['specifiers'][number]
+
+export function isIdentifier(
+  node: unknown,
+): node is { type: 'Identifier'; name: string } {
+  return (
+    !!node &&
+    typeof node === 'object' &&
+    (node as { type?: string }).type === 'Identifier'
+  )
+}
+
+export function isCallExpression(node: unknown): node is CallExpressionNode {
+  return (
+    !!node &&
+    typeof node === 'object' &&
+    (node as { type?: string }).type === 'CallExpression'
+  )
+}
+
+export function getRequiredRange(node: {
+  range?: [number, number]
+}): [number, number] {
+  if (!node.range) {
+    throw new Error('Expected node to have a range.')
+  }
+
+  return node.range
+}
+
+function isAstNode(node: unknown): node is GenericAstNode {
+  return (
+    !!node &&
+    typeof node === 'object' &&
+    typeof (node as { type?: unknown }).type === 'string'
+  )
+}
+
+export function unwrapExpression(node: unknown): unknown {
+  let current = node
+
+  while (isAstNode(current)) {
+    switch (current.type) {
+      case 'ParenthesizedExpression':
+      case 'TSAsExpression':
+      case 'TSSatisfiesExpression':
+      case 'TSNonNullExpression':
+        current = (current as unknown as { expression: unknown }).expression
+        continue
+      default:
+        return current
+    }
+  }
+
+  return current
+}
+
+export function getCallToLocalNames(
+  node: unknown,
+  localNames: Set<string>,
+): CallExpressionNode | undefined {
+  const unwrappedNode = unwrapExpression(node)
+  return isCallExpression(unwrappedNode) &&
+    isIdentifier(unwrappedNode.callee) &&
+    localNames.has(unwrappedNode.callee.name)
+    ? unwrappedNode
+    : undefined
+}
+
+export function visitAst(
+  node: unknown,
+  visitor: (node: GenericAstNode, parent: GenericAstNode | null) => void,
+  parent: GenericAstNode | null = null,
+): void {
+  if (!isAstNode(node)) {
+    return
+  }
+
+  visitor(node, parent)
+
+  for (const [key, value] of Object.entries(node)) {
+    if (key === 'parent' || key === 'range' || key === 'loc') {
+      continue
+    }
+
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        visitAst(item, visitor, node)
+      }
+      continue
+    }
+
+    visitAst(value, visitor, node)
+  }
+}
+
+export function getNodeText(sourceCode: SourceCode, node: unknown): string {
+  return sourceCode.getText(node as never)
+}
+
+export function getStatementRemovalRange(
+  sourceCode: SourceCode,
+  statement: { range?: [number, number] },
+): [number, number] {
+  const text = sourceCode.getText()
+  const range = getRequiredRange(statement)
+  let start = range[0]
+  while (start > 0 && text[start - 1] !== '\n') {
+    start--
+  }
+
+  let end = range[1]
+  while (end < text.length && text[end] !== '\n') {
+    end++
+  }
+  if (text[end] === '\n') {
+    end++
+  }
+
+  let nextLineEnd = end
+  while (nextLineEnd < text.length && text[nextLineEnd] !== '\n') {
+    nextLineEnd++
+  }
+
+  if (text.slice(end, nextLineEnd).trim() === '') {
+    end = nextLineEnd
+    if (text[end] === '\n') {
+      end++
+    }
+  }
+
+  return [start, end]
+}

--- a/src/migrations/toWithVueTs.ts
+++ b/src/migrations/toWithVueTs.ts
@@ -1,0 +1,882 @@
+import path from 'node:path'
+
+import { Linter, type SourceCode } from 'eslint'
+import type { Rule } from 'eslint'
+import tseslint from 'typescript-eslint'
+
+import {
+  getCallToLocalNames,
+  getNodeText,
+  getRequiredRange,
+  getStatementRemovalRange,
+  isIdentifier,
+  unwrapExpression,
+  visitAst,
+  type CallExpressionNode,
+  type ExpressionStatementNode,
+  type ExportDefaultDeclarationNode,
+  type IdentifierNode,
+  type IdentifierUsage,
+  type ImportDeclarationNode,
+} from './astHelpers'
+
+const MIGRATION_PLUGIN_NAME = 'vue-ts-migrate'
+const MIGRATION_RULE_NAME = 'to-with-vue-ts'
+const MIGRATION_RULE_ID = `${MIGRATION_PLUGIN_NAME}/${MIGRATION_RULE_NAME}`
+const PACKAGE_NAME = '@vue/eslint-config-typescript'
+
+const LEGACY_HELPER_IMPORTS = new Set(['defineConfigWithVueTs', 'defineConfig'])
+const PROJECT_OPTIONS_KEYS = new Set([
+  'tsSyntaxInTemplates',
+  'scriptLangs',
+  'allowComponentTypeUnsafety',
+  'includeDotFolders',
+  'rootDir',
+])
+
+type TextEdit = {
+  range: [number, number]
+  text: string
+}
+
+export type ToWithVueTsMigrationAnalysis =
+  | {
+      status: 'noop'
+    }
+  | {
+      status: 'parse-error'
+      reason: string
+    }
+  | {
+      status: 'unsupported'
+      reasons: string[]
+    }
+  | {
+      status: 'fixable'
+      changes: string[]
+      edits: TextEdit[]
+    }
+
+export type AppliedToWithVueTsMigration = {
+  analysis: ToWithVueTsMigrationAnalysis
+  changed: boolean
+  output: string
+}
+
+type PackageImportSpecifier = ImportDeclarationNode['specifiers'][number]
+
+type ImportCollection = {
+  declarations: ImportDeclarationNode[]
+  legacyHelperLocalNames: Set<string>
+  configureVueProjectLocalNames: Set<string>
+  withVueTsLocalName?: string
+  unsupportedReasons: string[]
+}
+
+type LegacyTarget = {
+  call: CallExpressionNode
+  helperLocalName: string
+}
+
+type ConfigureVueProjectStatement = {
+  statement: ExpressionStatementNode
+  call: CallExpressionNode
+}
+
+type MigrationFacts = {
+  imports: ImportCollection
+  configureStatements: ConfigureVueProjectStatement[]
+  legacyTarget?: LegacyTarget
+}
+
+type FixableMigrationFacts = MigrationFacts & {
+  legacyTarget: LegacyTarget
+}
+
+type TopLevelVariableTarget = {
+  call: CallExpressionNode
+  kind: 'const' | 'let' | 'var'
+}
+
+type FirstArgumentClassification = 'config' | 'options' | 'ambiguous-options'
+
+function isTsConfigFile(filename: string): boolean {
+  return ['.ts', '.mts'].includes(path.extname(filename))
+}
+
+function getLintFilename(filename: string): string {
+  return path.basename(filename)
+}
+
+function getBaseConfig(filename: string): Linter.Config[] {
+  return [
+    {
+      files: [
+        '**/*.js',
+        '**/*.mjs',
+        '**/*.ts',
+        '**/*.mts',
+        'eslint.config.js',
+        'eslint.config.mjs',
+        'eslint.config.ts',
+        'eslint.config.mts',
+        '**/eslint.config.js',
+        '**/eslint.config.mjs',
+        '**/eslint.config.ts',
+        '**/eslint.config.mts',
+      ],
+      languageOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+        ...(isTsConfigFile(filename) ? { parser: tseslint.parser } : {}),
+      },
+    },
+  ]
+}
+
+function parseSourceCode(
+  text: string,
+  filename: string,
+): { sourceCode?: SourceCode; error?: string } {
+  const lintFilename = getLintFilename(filename)
+  const linter = new Linter({ configType: 'flat' })
+  const messages = linter.verify(text, getBaseConfig(lintFilename), {
+    filename: lintFilename,
+  })
+  const sourceCode = linter.getSourceCode()
+  if (!sourceCode) {
+    return {
+      error:
+        messages.find(message => message.fatal)?.message ??
+        messages[0]?.message,
+    }
+  }
+
+  return {
+    sourceCode,
+  }
+}
+
+function getImportSpecifierImportedName(
+  specifier: PackageImportSpecifier,
+): string | undefined {
+  if (specifier.type !== 'ImportSpecifier') {
+    return
+  }
+
+  if (typeof specifier.imported === 'string') {
+    return specifier.imported
+  }
+
+  const imported = specifier.imported as {
+    name?: string
+    value?: string
+  }
+  return imported.name ?? imported.value
+}
+
+function collectVueImports(sourceCode: SourceCode): ImportCollection {
+  const declarations: ImportDeclarationNode[] = []
+  const legacyHelperLocalNames = new Set<string>()
+  const configureVueProjectLocalNames = new Set<string>()
+  let withVueTsLocalName: string | undefined
+  const unsupportedReasons: string[] = []
+
+  for (const statement of sourceCode.ast.body) {
+    if (statement.type !== 'ImportDeclaration') {
+      continue
+    }
+    if (statement.source.value !== PACKAGE_NAME) {
+      continue
+    }
+
+    declarations.push(statement)
+
+    for (const specifier of statement.specifiers) {
+      if (specifier.type === 'ImportDefaultSpecifier') {
+        unsupportedReasons.push(
+          'Default `createConfig()` imports are not supported by this migration yet.',
+        )
+        continue
+      }
+      if (specifier.type === 'ImportNamespaceSpecifier') {
+        unsupportedReasons.push(
+          'Namespace imports from `@vue/eslint-config-typescript` are not supported by this migration yet.',
+        )
+        continue
+      }
+
+      const importedName = getImportSpecifierImportedName(specifier)
+      if (!importedName) {
+        continue
+      }
+
+      if (LEGACY_HELPER_IMPORTS.has(importedName)) {
+        legacyHelperLocalNames.add(specifier.local.name)
+      }
+
+      if (importedName === 'configureVueProject') {
+        configureVueProjectLocalNames.add(specifier.local.name)
+      }
+
+      if (importedName === 'withVueTs') {
+        withVueTsLocalName = specifier.local.name
+      }
+
+      if (importedName === 'createConfig') {
+        unsupportedReasons.push(
+          '`createConfig()` uses the older array-spread API and is not supported by this migration yet.',
+        )
+      }
+    }
+  }
+
+  return {
+    declarations,
+    legacyHelperLocalNames,
+    configureVueProjectLocalNames,
+    withVueTsLocalName,
+    unsupportedReasons,
+  }
+}
+
+function findConfigureVueProjectStatements(
+  sourceCode: SourceCode,
+  localNames: Set<string>,
+): ConfigureVueProjectStatement[] {
+  if (localNames.size === 0) {
+    return []
+  }
+
+  return sourceCode.ast.body.flatMap(statement => {
+    if (statement.type !== 'ExpressionStatement') {
+      return []
+    }
+
+    const call = getCallToLocalNames(statement.expression, localNames)
+    return call ? [{ statement, call }] : []
+  })
+}
+
+function findLocalNameUsages(
+  sourceCode: SourceCode,
+  localNames: Set<string>,
+): IdentifierUsage[] {
+  const usages: IdentifierUsage[] = []
+
+  visitAst(sourceCode.ast, (node, parent) => {
+    if (
+      node.type !== 'Identifier' ||
+      !localNames.has((node as IdentifierNode).name)
+    ) {
+      return
+    }
+
+    usages.push({
+      identifier: node as IdentifierNode,
+      parent,
+    })
+  })
+
+  return usages
+}
+
+function isIgnoredConfigureUsage(
+  usage: IdentifierUsage,
+  supportedCalls: Set<CallExpressionNode>,
+): boolean {
+  const { identifier, parent } = usage
+  if (!parent) {
+    return false
+  }
+
+  if (
+    (parent.type === 'ImportSpecifier' ||
+      parent.type === 'ImportDefaultSpecifier' ||
+      parent.type === 'ImportNamespaceSpecifier') &&
+    ((parent as { local?: unknown }).local === identifier ||
+      (parent as { imported?: unknown }).imported === identifier)
+  ) {
+    return true
+  }
+
+  if (
+    (parent.type === 'Property' ||
+      parent.type === 'PropertyDefinition' ||
+      parent.type === 'MethodDefinition') &&
+    (parent as { key?: unknown; computed?: boolean }).key === identifier &&
+    !(parent as { computed?: boolean }).computed
+  ) {
+    return true
+  }
+
+  if (
+    parent.type === 'MemberExpression' &&
+    (parent as { property?: unknown; computed?: boolean }).property ===
+      identifier &&
+    !(parent as { computed?: boolean }).computed
+  ) {
+    return true
+  }
+
+  if (
+    parent.type === 'CallExpression' &&
+    (parent as { callee?: unknown }).callee === identifier &&
+    supportedCalls.has(parent as unknown as CallExpressionNode)
+  ) {
+    return true
+  }
+
+  return false
+}
+
+function findLegacyTarget(
+  sourceCode: SourceCode,
+  localNames: Set<string>,
+): LegacyTarget | undefined {
+  if (localNames.size === 0) {
+    return
+  }
+
+  const topLevelVariables = new Map<string, TopLevelVariableTarget>()
+
+  for (const statement of sourceCode.ast.body) {
+    if (statement.type !== 'VariableDeclaration') {
+      continue
+    }
+    if (
+      statement.kind !== 'const' &&
+      statement.kind !== 'let' &&
+      statement.kind !== 'var'
+    ) {
+      continue
+    }
+
+    for (const declaration of statement.declarations) {
+      if (!isIdentifier(declaration.id)) {
+        continue
+      }
+      const call = getCallToLocalNames(declaration.init, localNames)
+      if (!call) {
+        continue
+      }
+
+      topLevelVariables.set(declaration.id.name, { call, kind: statement.kind })
+    }
+  }
+
+  const exportDefault = sourceCode.ast.body.find(
+    statement => statement.type === 'ExportDefaultDeclaration',
+  ) as ExportDefaultDeclarationNode | undefined
+  if (!exportDefault) {
+    return
+  }
+
+  const directCall = getCallToLocalNames(exportDefault.declaration, localNames)
+  if (directCall) {
+    const callee = directCall.callee as { name: string }
+    return {
+      call: directCall,
+      helperLocalName: callee.name,
+    }
+  }
+
+  const unwrappedDeclaration = unwrapExpression(exportDefault.declaration)
+  if (!isIdentifier(unwrappedDeclaration)) {
+    return
+  }
+
+  const target = topLevelVariables.get(unwrappedDeclaration.name)
+  if (!target || target.kind !== 'const' || !isIdentifier(target.call.callee)) {
+    return
+  }
+
+  return {
+    call: target.call,
+    helperLocalName: target.call.callee.name,
+  }
+}
+
+function formatMultilineCall(calleeText: string, argsText: string[]): string {
+  if (argsText.length === 0) {
+    return `${calleeText}()`
+  }
+
+  const formattedArgs = argsText
+    .map(arg =>
+      arg
+        .split('\n')
+        .map(line => `  ${line}`)
+        .join('\n'),
+    )
+    .join(',\n')
+
+  return `${calleeText}(\n${formattedArgs},\n)`
+}
+
+function buildImportEdits(
+  sourceCode: SourceCode,
+  imports: ImportDeclarationNode[],
+  withVueTsLocalName: string,
+): TextEdit[] {
+  const primaryImport =
+    imports.find(statement =>
+      statement.specifiers.some(
+        specifier =>
+          specifier.type === 'ImportSpecifier' &&
+          getImportSpecifierImportedName(specifier) === 'withVueTs',
+      ),
+    ) ?? imports[0]
+
+  return imports
+    .map<TextEdit | undefined>(statement => {
+      const keptNamedSpecifiers = statement.specifiers
+        .filter(
+          specifier =>
+            specifier.type === 'ImportSpecifier' &&
+            !LEGACY_HELPER_IMPORTS.has(
+              getImportSpecifierImportedName(specifier) ?? '',
+            ) &&
+            getImportSpecifierImportedName(specifier) !== 'configureVueProject',
+        )
+        .map(specifier => sourceCode.getText(specifier))
+
+      const hasWithVueTsSpecifier = statement.specifiers.some(
+        specifier =>
+          specifier.type === 'ImportSpecifier' &&
+          getImportSpecifierImportedName(specifier) === 'withVueTs',
+      )
+
+      if (statement === primaryImport && !hasWithVueTsSpecifier) {
+        keptNamedSpecifiers.unshift(
+          withVueTsLocalName === 'withVueTs'
+            ? 'withVueTs'
+            : `withVueTs as ${withVueTsLocalName}`,
+        )
+      }
+
+      if (keptNamedSpecifiers.length === 0) {
+        return {
+          range: getStatementRemovalRange(sourceCode, statement),
+          text: '',
+        }
+      }
+
+      const statementText = sourceCode.getText(statement)
+      const semicolon = statementText.trimEnd().endsWith(';') ? ';' : ''
+
+      return {
+        range: getRequiredRange(statement),
+        text: `import { ${keptNamedSpecifiers.join(', ')} } from ${sourceCode.getText(statement.source)}${semicolon}`,
+      }
+    })
+    .filter((edit): edit is TextEdit => !!edit)
+}
+
+function classifyFirstArgument(
+  call: CallExpressionNode,
+): FirstArgumentClassification {
+  const firstArg = unwrapExpression(call.arguments[0])
+  if (
+    !firstArg ||
+    typeof firstArg !== 'object' ||
+    Array.isArray(firstArg) ||
+    (firstArg as { type?: string }).type !== 'ObjectExpression'
+  ) {
+    return 'config'
+  }
+
+  const properties = (
+    firstArg as {
+      properties: Array<
+        | { type: 'SpreadElement' }
+        | {
+            type: 'Property'
+            computed?: boolean
+            key: { type?: string; name?: string; value?: string }
+          }
+      >
+    }
+  ).properties
+
+  let sawProjectOptionKey = false
+  let sawNonProjectOptionKey = false
+  let sawAmbiguousProperty = false
+
+  for (const property of properties) {
+    if (property.type === 'SpreadElement') {
+      sawAmbiguousProperty = true
+      continue
+    }
+
+    if (property.type !== 'Property' || property.computed) {
+      sawAmbiguousProperty = true
+      continue
+    }
+
+    let propertyName: string | undefined
+    if (property.key.type === 'Identifier') {
+      propertyName = property.key.name
+    } else if (
+      property.key.type === 'Literal' &&
+      typeof property.key.value === 'string'
+    ) {
+      propertyName = property.key.value
+    }
+
+    if (!propertyName) {
+      sawAmbiguousProperty = true
+      continue
+    }
+
+    if (PROJECT_OPTIONS_KEYS.has(propertyName)) {
+      sawProjectOptionKey = true
+    } else {
+      sawNonProjectOptionKey = true
+    }
+  }
+
+  if (sawProjectOptionKey && !sawNonProjectOptionKey && !sawAmbiguousProperty) {
+    return 'options'
+  }
+
+  if (sawProjectOptionKey || sawAmbiguousProperty) {
+    return 'ambiguous-options'
+  }
+
+  return 'config'
+}
+
+export function analyzeToWithVueTsMigrationText(
+  text: string,
+  filename: string,
+): ToWithVueTsMigrationAnalysis {
+  const parsed = parseSourceCode(text, filename)
+  if (!parsed.sourceCode) {
+    return {
+      status: 'parse-error',
+      reason: parsed.error ?? 'Unknown parser error.',
+    }
+  }
+
+  return analyzeToWithVueTsMigrationSourceCode(parsed.sourceCode)
+}
+
+export function analyzeToWithVueTsMigrationSourceCode(
+  sourceCode: SourceCode,
+): ToWithVueTsMigrationAnalysis {
+  const facts = collectMigrationFacts(sourceCode)
+  if (facts.imports.declarations.length === 0) {
+    return { status: 'noop' }
+  }
+
+  const structuralUnsupportedReasons = getStructuralUnsupportedReasons(
+    sourceCode,
+    facts,
+  )
+  if (structuralUnsupportedReasons.length > 0) {
+    return {
+      status: 'unsupported',
+      reasons: structuralUnsupportedReasons,
+    }
+  }
+
+  if (!facts.legacyTarget) {
+    return { status: 'noop' }
+  }
+
+  if (isAlreadyUsingWithVueTs(facts)) {
+    return { status: 'noop' }
+  }
+
+  const callUnsupportedReason = getLegacyCallUnsupportedReason(
+    facts.legacyTarget.call,
+  )
+  if (callUnsupportedReason) {
+    return {
+      status: 'unsupported',
+      reasons: [callUnsupportedReason],
+    }
+  }
+
+  return buildFixableMigrationAnalysis(sourceCode, {
+    ...facts,
+    legacyTarget: facts.legacyTarget,
+  })
+}
+
+function collectMigrationFacts(sourceCode: SourceCode): MigrationFacts {
+  const imports = collectVueImports(sourceCode)
+
+  return {
+    imports,
+    configureStatements: findConfigureVueProjectStatements(
+      sourceCode,
+      imports.configureVueProjectLocalNames,
+    ),
+    legacyTarget: findLegacyTarget(sourceCode, imports.legacyHelperLocalNames),
+  }
+}
+
+function getStructuralUnsupportedReasons(
+  sourceCode: SourceCode,
+  facts: MigrationFacts,
+): string[] {
+  return [
+    ...new Set([
+      ...facts.imports.unsupportedReasons,
+      ...getConfigureVueProjectUnsupportedReasons(sourceCode, facts),
+      ...getLegacyTargetUnsupportedReasons(facts),
+    ]),
+  ]
+}
+
+function getConfigureVueProjectUnsupportedReasons(
+  sourceCode: SourceCode,
+  facts: MigrationFacts,
+): string[] {
+  const reasons: string[] = []
+  const configureUsages = findLocalNameUsages(
+    sourceCode,
+    facts.imports.configureVueProjectLocalNames,
+  )
+  const supportedConfigureCalls = new Set(
+    facts.configureStatements.map(
+      configureStatement => configureStatement.call,
+    ),
+  )
+
+  if (
+    configureUsages.some(
+      usage => !isIgnoredConfigureUsage(usage, supportedConfigureCalls),
+    )
+  ) {
+    reasons.push(
+      'Only top-level `configureVueProject(...)` calls are supported by this migration.',
+    )
+  }
+  if (facts.configureStatements.length > 1) {
+    reasons.push(
+      'Multiple `configureVueProject()` calls are not supported by this migration.',
+    )
+  }
+
+  return reasons
+}
+
+function getLegacyTargetUnsupportedReasons(facts: MigrationFacts): string[] {
+  const reasons: string[] = []
+
+  if (facts.imports.legacyHelperLocalNames.size > 0 && !facts.legacyTarget) {
+    reasons.push(
+      '`defineConfigWithVueTs()` must be exported directly, or assigned to a top-level variable that is exported as default, for this migration to rewrite it safely.',
+    )
+  }
+  if (facts.configureStatements.length > 0 && !facts.legacyTarget) {
+    reasons.push(
+      '`configureVueProject()` was found, but this file does not export `defineConfigWithVueTs()`. Manual migration is required.',
+    )
+  }
+  return reasons
+}
+
+function isAlreadyUsingWithVueTs(facts: MigrationFacts): boolean {
+  return (
+    !!facts.legacyTarget &&
+    !!facts.imports.withVueTsLocalName &&
+    facts.imports.withVueTsLocalName === facts.legacyTarget.helperLocalName
+  )
+}
+
+function getLegacyCallUnsupportedReason(
+  call: CallExpressionNode,
+): string | undefined {
+  const firstArgumentKind = classifyFirstArgument(call)
+  if (firstArgumentKind === 'options') {
+    return '`defineConfigWithVueTs()` does not accept project options. This file appears to be partially migrated already.'
+  }
+  if (firstArgumentKind === 'ambiguous-options') {
+    return 'The first argument to `defineConfigWithVueTs()` could be reinterpreted as `withVueTs()` project options. Please migrate this case manually.'
+  }
+}
+
+function buildFixableMigrationAnalysis(
+  sourceCode: SourceCode,
+  facts: FixableMigrationFacts,
+): ToWithVueTsMigrationAnalysis {
+  const withVueTsLocalName = facts.imports.withVueTsLocalName ?? 'withVueTs'
+  const configureArgText = getConfigureVueProjectOptionsText(
+    sourceCode,
+    facts.configureStatements[0],
+  )
+  const replacementArgs = getWithVueTsReplacementArgs(
+    sourceCode,
+    facts.legacyTarget,
+    configureArgText,
+  )
+  const edits = buildMigrationEdits(
+    sourceCode,
+    facts,
+    withVueTsLocalName,
+    replacementArgs,
+  )
+  const changes = getMigrationChanges(
+    facts.legacyTarget.helperLocalName,
+    withVueTsLocalName,
+    configureArgText,
+  )
+
+  return {
+    status: 'fixable',
+    changes,
+    edits,
+  }
+}
+
+function getConfigureVueProjectOptionsText(
+  sourceCode: SourceCode,
+  configureStatement: ConfigureVueProjectStatement | undefined,
+): string | undefined {
+  const firstArg = configureStatement?.call.arguments[0]
+  return firstArg === undefined ? undefined : getNodeText(sourceCode, firstArg)
+}
+
+function getWithVueTsReplacementArgs(
+  sourceCode: SourceCode,
+  legacyTarget: LegacyTarget,
+  configureArgText: string | undefined,
+): string[] {
+  return [
+    ...(configureArgText ? [configureArgText] : []),
+    ...legacyTarget.call.arguments.map(argument =>
+      getNodeText(sourceCode, argument),
+    ),
+  ]
+}
+
+function buildMigrationEdits(
+  sourceCode: SourceCode,
+  facts: FixableMigrationFacts,
+  withVueTsLocalName: string,
+  replacementArgs: string[],
+): TextEdit[] {
+  const edits: TextEdit[] = [
+    {
+      range: getRequiredRange(facts.legacyTarget.call),
+      text: formatMultilineCall(withVueTsLocalName, replacementArgs),
+    },
+    ...buildImportEdits(
+      sourceCode,
+      facts.imports.declarations,
+      withVueTsLocalName,
+    ),
+  ]
+
+  if (facts.configureStatements[0]) {
+    edits.push({
+      range: getStatementRemovalRange(
+        sourceCode,
+        facts.configureStatements[0].statement,
+      ),
+      text: '',
+    })
+  }
+
+  return edits.sort((a, b) => a.range[0] - b.range[0])
+}
+
+function getMigrationChanges(
+  legacyHelperLocalName: string,
+  withVueTsLocalName: string,
+  configureArgText: string | undefined,
+): string[] {
+  return [
+    `replace \`${legacyHelperLocalName}(...)\` with \`${withVueTsLocalName}(...)\``,
+    'rewrite imports from `@vue/eslint-config-typescript`',
+    ...(configureArgText
+      ? ['inline `configureVueProject(...)` options into `withVueTs(...)`']
+      : []),
+  ]
+}
+
+const migrateToWithVueTsRule: Rule.RuleModule = {
+  meta: {
+    type: 'suggestion',
+    fixable: 'code',
+    docs: {
+      description:
+        'migrate legacy @vue/eslint-config-typescript helper usage to withVueTs',
+    },
+    schema: [],
+    messages: {
+      migrate:
+        'Legacy @vue/eslint-config-typescript helper usage can be migrated to `withVueTs(...)`.',
+    },
+  },
+  create(context) {
+    return {
+      Program(node) {
+        const analysis = analyzeToWithVueTsMigrationSourceCode(
+          context.sourceCode,
+        )
+        if (analysis.status !== 'fixable') {
+          return
+        }
+
+        context.report({
+          node,
+          messageId: 'migrate',
+          fix(fixer) {
+            return analysis.edits.map(edit =>
+              fixer.replaceTextRange(edit.range, edit.text),
+            )
+          },
+        })
+      },
+    }
+  },
+}
+
+function getFixConfig(filename: string): Linter.Config[] {
+  return [
+    {
+      ...getBaseConfig(filename)[0],
+      plugins: {
+        [MIGRATION_PLUGIN_NAME]: {
+          rules: {
+            [MIGRATION_RULE_NAME]: migrateToWithVueTsRule,
+          },
+        },
+      },
+      rules: {
+        [MIGRATION_RULE_ID]: 'error',
+      },
+    },
+  ]
+}
+
+export function applyToWithVueTsMigrationText(
+  text: string,
+  filename: string,
+): AppliedToWithVueTsMigration {
+  const analysis = analyzeToWithVueTsMigrationText(text, filename)
+  if (analysis.status !== 'fixable') {
+    return {
+      analysis,
+      changed: false,
+      output: text,
+    }
+  }
+
+  const linter = new Linter({ configType: 'flat' })
+  const lintFilename = getLintFilename(filename)
+  const report = linter.verifyAndFix(text, getFixConfig(lintFilename), {
+    filename: lintFilename,
+  })
+
+  return {
+    analysis,
+    changed: report.fixed,
+    output: report.output ?? text,
+  }
+}

--- a/src/utilities.ts
+++ b/src/utilities.ts
@@ -4,7 +4,12 @@ import type { TSESLint } from '@typescript-eslint/utils'
 import type { FlatConfig } from '@typescript-eslint/utils/ts-eslint'
 import pluginVue from 'eslint-plugin-vue'
 
-import { TsEslintConfigForVue } from './configs'
+import {
+  extendVueTsConfig,
+  isVueTsConfig,
+  resolveVueTsConfig,
+  vueTsConfigNeedsTypeChecking,
+} from './configs'
 import groupVueFiles from './groupVueFiles'
 import {
   additionalRulesRequiringParserServices,
@@ -17,12 +22,9 @@ import type { ScriptLang } from './internals'
 import { omit, pipe, partition } from './fpHelpers'
 
 type ConfigItem = TSESLint.FlatConfig.Config
-type InfiniteDepthConfigWithExtendsAndVueSupport =
-  | TsEslintConfigForVue
-  | ConfigItemWithExtendsAndVueSupport
-  | InfiniteDepthConfigWithExtendsAndVueSupport[]
+type ConfigInput = ConfigItemWithExtendsAndVueSupport | ConfigInput[]
 interface ConfigItemWithExtendsAndVueSupport extends ConfigItem {
-  extends?: InfiniteDepthConfigWithExtendsAndVueSupport[]
+  extends?: ConfigInput[]
 }
 
 export type ProjectOptions = {
@@ -75,13 +77,159 @@ export type ProjectOptions = {
   rootDir?: string
 }
 
-let projectOptions = {
-  tsSyntaxInTemplates: true as boolean,
-  scriptLangs: ['ts'] as ScriptLang[],
-  allowComponentTypeUnsafety: true as boolean,
-  includeDotFolders: false as boolean,
+type ResolvedProjectOptions = {
+  tsSyntaxInTemplates: boolean
+  scriptLangs: ScriptLang[]
+  allowComponentTypeUnsafety: boolean
+  includeDotFolders: boolean
+  rootDir: string
+}
+
+type RawConfigItem = ConfigItem
+
+type ExtractedConfig = {
+  files?: (string | string[])[]
+  rules: NonNullable<ConfigItem['rules']>
+}
+
+type TransformState = {
+  globalIgnores: string[]
+  userTypeAwareConfigs: ExtractedConfig[]
+}
+
+type MaybePromise<T> = T | PromiseLike<T>
+type AwaitableConfigInput = MaybePromise<ConfigInput | ConfigInput[]>
+
+const PROJECT_OPTION_KEYS = new Set([
+  'tsSyntaxInTemplates',
+  'scriptLangs',
+  'allowComponentTypeUnsafety',
+  'includeDotFolders',
+  'rootDir',
+])
+
+const DEFAULT_PROJECT_OPTIONS = {
+  tsSyntaxInTemplates: true,
+  scriptLangs: ['ts'],
+  allowComponentTypeUnsafety: true,
+  includeDotFolders: false,
   rootDir: process.cwd(),
-} satisfies ProjectOptions
+} satisfies ResolvedProjectOptions
+
+let projectOptions: ResolvedProjectOptions = { ...DEFAULT_PROJECT_OPTIONS }
+
+function resolveProjectOptions(
+  userOptions: ProjectOptions = {},
+): ResolvedProjectOptions {
+  return {
+    tsSyntaxInTemplates:
+      userOptions.tsSyntaxInTemplates ?? projectOptions.tsSyntaxInTemplates,
+    scriptLangs: userOptions.scriptLangs ?? projectOptions.scriptLangs,
+    allowComponentTypeUnsafety:
+      userOptions.allowComponentTypeUnsafety ??
+      projectOptions.allowComponentTypeUnsafety,
+    includeDotFolders:
+      userOptions.includeDotFolders ?? projectOptions.includeDotFolders,
+    rootDir: userOptions.rootDir ?? projectOptions.rootDir,
+  }
+}
+
+function createTransformState(): TransformState {
+  return {
+    globalIgnores: [],
+    userTypeAwareConfigs: [],
+  }
+}
+
+function normalizeConfigInput(
+  config: ConfigInput | ConfigInput[],
+): ConfigInput[] {
+  return Array.isArray(config) ? config : [config]
+}
+
+function isPlainObject(
+  value: unknown,
+): value is Record<string | number | symbol, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return false
+  }
+
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function classifyFirstArg(
+  value: unknown,
+): 'options' | 'config' | 'mixed-options-and-config' {
+  if (!isPlainObject(value)) {
+    return 'config'
+  }
+
+  const keys = Object.keys(value)
+  if (keys.length === 0) {
+    return 'config'
+  }
+
+  const optionKeyCount = keys.filter(key => PROJECT_OPTION_KEYS.has(key)).length
+  if (optionKeyCount === 0) {
+    return 'config'
+  }
+  if (optionKeyCount === keys.length) {
+    return 'options'
+  }
+
+  return 'mixed-options-and-config'
+}
+
+function splitOptionsAndConfigInputs(args: unknown[]): {
+  configInputs: AwaitableConfigInput[]
+  userOptions: ProjectOptions
+} {
+  if (args.length === 0) {
+    return {
+      configInputs: [],
+      userOptions: {},
+    }
+  }
+
+  const firstArg = args[0]
+  const firstArgKind = classifyFirstArg(firstArg)
+
+  if (firstArgKind === 'mixed-options-and-config') {
+    throw new TypeError(
+      'The first argument to `withVueTs(...)` cannot mix Vue project options with ESLint config keys. Pass project options as the first argument and move ESLint config fields into a separate config object.',
+    )
+  }
+
+  if (firstArgKind !== 'options') {
+    return {
+      configInputs: args as AwaitableConfigInput[],
+      userOptions: {},
+    }
+  }
+
+  return {
+    configInputs: args.slice(1) as AwaitableConfigInput[],
+    userOptions: firstArg as ProjectOptions,
+  }
+}
+
+function applyVueTsTransform(
+  configs: ConfigInput[],
+  options: ResolvedProjectOptions,
+): ConfigItem[] {
+  const state = createTransformState()
+
+  return pipe(
+    configs,
+    flattenConfigs,
+    rawConfigs => collectGlobalIgnores(rawConfigs, state),
+    deduplicateVuePlugin,
+    rawConfigs => insertAndReorderConfigs(rawConfigs, options, state),
+    resolveVueTsConfigs,
+    tseslint.config, // this might not be necessary, but it doesn't hurt to keep it
+  )
+}
 
 // This function, if called, is guaranteed to be executed before `defineConfigWithVueTs`,
 // so mutating the `projectOptions` object is safe and will be reflected in the final ESLint config.
@@ -99,47 +247,51 @@ export function configureVueProject(userOptions: ProjectOptions): void {
   if (userOptions.rootDir) {
     projectOptions.rootDir = userOptions.rootDir
   }
-  if (userOptions.includeDotFolders) {
+  if (userOptions.includeDotFolders !== undefined) {
     projectOptions.includeDotFolders = userOptions.includeDotFolders
   }
 }
 
-// The *Raw* types are those with placeholders not yet resolved.
-type RawConfigItemWithExtends =
-  | ConfigItemWithExtendsAndVueSupport
-  | TsEslintConfigForVue
-type RawConfigItem = ConfigItem | TsEslintConfigForVue
+export function defineConfigWithVueTs(...configs: ConfigInput[]): ConfigItem[] {
+  return applyVueTsTransform(configs, resolveProjectOptions())
+}
 
-export function defineConfigWithVueTs(
-  ...configs: InfiniteDepthConfigWithExtendsAndVueSupport[]
-): ConfigItem[] {
-  return pipe(
-    configs,
-    flattenConfigs,
-    collectGlobalIgnores,
-    deduplicateVuePlugin,
-    insertAndReorderConfigs,
-    resolveVueTsConfigs,
-    tseslint.config, // this might not be necessary, but it doesn't hurt to keep it
+export function withVueTs(
+  ...configs: AwaitableConfigInput[]
+): Promise<ConfigItem[]>
+export function withVueTs(
+  options: ProjectOptions,
+  ...configs: AwaitableConfigInput[]
+): Promise<ConfigItem[]>
+export async function withVueTs(...args: unknown[]): Promise<ConfigItem[]> {
+  const { configInputs, userOptions } = splitOptionsAndConfigInputs(args)
+  const resolvedConfigs = await Promise.all(configInputs)
+
+  return applyVueTsTransform(
+    resolvedConfigs.flatMap(config => normalizeConfigInput(config)),
+    resolveProjectOptions(userOptions),
   )
 }
 
-function flattenConfigs(
-  configs: InfiniteDepthConfigWithExtendsAndVueSupport[],
-): RawConfigItem[] {
+function flattenConfigs(configs: ConfigInput[]): RawConfigItem[] {
   // Be careful that our TS types don't guarantee that `extends` is removed from the final config
   // Modified from
   // https://github.com/typescript-eslint/typescript-eslint/blob/d30a497ef470b5a06ca0a5dde9543b6e00c87a5f/packages/typescript-eslint/src/config-helper.ts#L98-L143
   // No handling of undefined for now for simplicity
 
-  // @ts-expect-error -- intentionally an infinite type
-  return (configs.flat(Infinity) as RawConfigItemWithExtends[]).flatMap(
-    (c: RawConfigItemWithExtends): RawConfigItem | RawConfigItem[] => {
-      if (c instanceof TsEslintConfigForVue) {
-        return c
+  const flattenedConfigs = (configs as unknown[]).flat(
+    Infinity,
+  ) as ConfigItemWithExtendsAndVueSupport[]
+
+  return flattenedConfigs.flatMap(
+    (
+      config: ConfigItemWithExtendsAndVueSupport,
+    ): RawConfigItem | RawConfigItem[] => {
+      if (isVueTsConfig(config)) {
+        return config
       }
 
-      const { extends: extendsArray, ...restOfConfig } = c
+      const { extends: extendsArray, ...restOfConfig } = config
       if (extendsArray == null || extendsArray.length === 0) {
         return restOfConfig
       }
@@ -153,18 +305,18 @@ function flattenConfigs(
 
       return [
         ...flattenedExtends.map((extension: RawConfigItem) => {
-          if (extension instanceof TsEslintConfigForVue) {
-            return extension.asExtendedWith(restOfConfig)
-          } else {
-            const name = [restOfConfig.name, extension.name]
-              .filter(Boolean)
-              .join('__')
-            return {
-              ...extension,
-              ...(restOfConfig.files && { files: restOfConfig.files }),
-              ...(restOfConfig.ignores && { ignores: restOfConfig.ignores }),
-              ...(name && { name }),
-            }
+          if (isVueTsConfig(extension)) {
+            return extendVueTsConfig(extension, restOfConfig)
+          }
+
+          const name = [restOfConfig.name, extension.name]
+            .filter(Boolean)
+            .join('__')
+          return {
+            ...extension,
+            ...(restOfConfig.files && { files: restOfConfig.files }),
+            ...(restOfConfig.ignores && { ignores: restOfConfig.ignores }),
+            ...(name && { name }),
           }
         }),
 
@@ -178,40 +330,35 @@ function flattenConfigs(
   )
 }
 
-let globalIgnores: string[] = []
-
 /**
  * Fields that are considered metadata and not part of the config object.
  */
 const META_FIELDS = new Set(['name', 'basePath'])
 
-function collectGlobalIgnores(configs: RawConfigItem[]): RawConfigItem[] {
+function collectGlobalIgnores(
+  configs: RawConfigItem[],
+  state: TransformState,
+): RawConfigItem[] {
   configs.forEach(config => {
-    if (config instanceof TsEslintConfigForVue) return
-
-    if (!config.ignores) return
+    if (isVueTsConfig(config) || !config.ignores) {
+      return
+    }
 
     if (Object.keys(config).filter(key => !META_FIELDS.has(key)).length !== 1)
       return
 
     // Configs that only contain `ignores` (and possibly `name`/`basePath`) are treated as global ignores
-    globalIgnores.push(...config.ignores)
+    state.globalIgnores.push(...config.ignores)
   })
 
   return configs
 }
 
 function resolveVueTsConfigs(configs: RawConfigItem[]): ConfigItem[] {
-  return configs.flatMap(config =>
-    config instanceof TsEslintConfigForVue ? config.toConfigArray() : config,
+  return configs.map(config =>
+    isVueTsConfig(config) ? resolveVueTsConfig(config) : config,
   )
 }
-
-type ExtractedConfig = {
-  files?: (string | string[])[]
-  rules: NonNullable<ConfigItem['rules']>
-}
-const userTypeAwareConfigs: ExtractedConfig[] = []
 
 /**
  * This function reorders the config array to make sure it satisfies the following layout:
@@ -233,34 +380,41 @@ const userTypeAwareConfigs: ExtractedConfig[] = []
  *   '@vue/typescript/type-aware-rules-in-conflit-with-vue'
  * ```
  */
-function insertAndReorderConfigs(configs: RawConfigItem[]): RawConfigItem[] {
-  const lastExtendedConfigIndex = configs.findLastIndex(
-    config => config instanceof TsEslintConfigForVue,
+function insertAndReorderConfigs(
+  configs: RawConfigItem[],
+  options: ResolvedProjectOptions,
+  state: TransformState,
+): RawConfigItem[] {
+  const lastExtendedConfigIndex = configs.findLastIndex(config =>
+    isVueTsConfig(config),
   )
 
   if (lastExtendedConfigIndex === -1) {
     return configs
   }
 
+  // TODO: Avoid scanning all `.vue` files eagerly here. This should be deferred
+  // until we actually need file-by-file type-checkability information.
   const vueFiles = groupVueFiles(
-    projectOptions.rootDir,
-    globalIgnores,
-    projectOptions.includeDotFolders,
+    options.rootDir,
+    state.globalIgnores,
+    options.includeDotFolders,
   )
-  const configsWithoutTypeAwareRules = configs.map(extractTypeAwareRules)
+  const configsWithoutTypeAwareRules = configs.map(config =>
+    extractTypeAwareRules(config, state),
+  )
 
   const hasTypeAwareConfigs = configs.some(
-    config =>
-      config instanceof TsEslintConfigForVue && config.needsTypeChecking(),
+    config => isVueTsConfig(config) && vueTsConfigNeedsTypeChecking(config),
   )
   const needsTypeAwareLinting =
-    hasTypeAwareConfigs || userTypeAwareConfigs.length > 0
+    hasTypeAwareConfigs || state.userTypeAwareConfigs.length > 0
 
   return [
     ...configsWithoutTypeAwareRules.slice(0, lastExtendedConfigIndex + 1),
     ...createBasicSetupConfigs(
-      projectOptions.tsSyntaxInTemplates,
-      projectOptions.scriptLangs,
+      options.tsSyntaxInTemplates,
+      options.scriptLangs,
     ),
 
     // user-turned-off type-aware rules must come after the last extended config
@@ -268,14 +422,14 @@ function insertAndReorderConfigs(configs: RawConfigItem[]): RawConfigItem[] {
     // user-turned-on type-aware rules must come before skipping type-checking
     // in case some rules targets those can't be type-checked files
     // So we extract all type-aware rules by users and put them in the middle
-    ...userTypeAwareConfigs,
+    ...state.userTypeAwareConfigs,
 
     ...(needsTypeAwareLinting
       ? [
           ...createSkipTypeCheckingConfigs(vueFiles.nonTypeCheckable),
           ...createTypeCheckingConfigs(
             vueFiles.typeCheckable,
-            projectOptions.allowComponentTypeUnsafety,
+            options.allowComponentTypeUnsafety,
           ),
         ]
       : []),
@@ -284,12 +438,11 @@ function insertAndReorderConfigs(configs: RawConfigItem[]): RawConfigItem[] {
   ]
 }
 
-function extractTypeAwareRules(config: RawConfigItem): RawConfigItem {
-  if (config instanceof TsEslintConfigForVue) {
-    return config
-  }
-
-  if (!config.rules) {
+function extractTypeAwareRules(
+  config: RawConfigItem,
+  state: TransformState,
+): RawConfigItem {
+  if (isVueTsConfig(config) || !config.rules) {
     return config
   }
 
@@ -299,7 +452,7 @@ function extractTypeAwareRules(config: RawConfigItem): RawConfigItem {
   )
 
   if (typeAwareRuleEntries.length > 0) {
-    userTypeAwareConfigs.push({
+    state.userTypeAwareConfigs.push({
       rules: Object.fromEntries(typeAwareRuleEntries),
       ...(config.files && { files: config.files }),
     })
@@ -324,7 +477,7 @@ function doesRuleRequireTypeInformation(ruleName: string): boolean {
 
 function deduplicateVuePlugin(configs: RawConfigItem[]): RawConfigItem[] {
   return configs.map(config => {
-    if (config instanceof TsEslintConfigForVue || !config.plugins?.vue) {
+    if (isVueTsConfig(config) || !config.plugins?.vue) {
       return config
     }
 

--- a/test/fixtures/migrate-create-config/eslint.config.js
+++ b/test/fixtures/migrate-create-config/eslint.config.js
@@ -1,0 +1,7 @@
+import pluginVue from 'eslint-plugin-vue'
+import vueTsConfig from '@vue/eslint-config-typescript'
+
+export default [
+  ...pluginVue.configs['flat/essential'],
+  ...vueTsConfig({ extends: ['recommendedTypeChecked'] }),
+]

--- a/test/fixtures/migrate-legacy-js/eslint.config.js
+++ b/test/fixtures/migrate-legacy-js/eslint.config.js
@@ -1,0 +1,17 @@
+import pluginVue from 'eslint-plugin-vue'
+import {
+  defineConfigWithVueTs,
+  vueTsConfigs,
+  configureVueProject,
+} from '@vue/eslint-config-typescript'
+
+configureVueProject({
+  rootDir: import.meta.dirname,
+  scriptLangs: ['ts', 'js'],
+  includeDotFolders: true,
+})
+
+export default defineConfigWithVueTs(
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommendedTypeChecked,
+)

--- a/test/fixtures/migrate-legacy-ts/eslint.config.ts
+++ b/test/fixtures/migrate-legacy-ts/eslint.config.ts
@@ -1,0 +1,23 @@
+import pluginVue from 'eslint-plugin-vue'
+import {
+  defineConfigWithVueTs,
+  vueTsConfigs,
+  configureVueProject,
+} from '@vue/eslint-config-typescript'
+
+const projectOptions: {
+  rootDir: string
+  scriptLangs: ['ts', 'js']
+} = {
+  rootDir: import.meta.dirname,
+  scriptLangs: ['ts', 'js'],
+}
+
+configureVueProject(projectOptions)
+
+const config = defineConfigWithVueTs(
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+)
+
+export default config

--- a/test/fixtures/with-vue-ts-api/eslint.config.js
+++ b/test/fixtures/with-vue-ts-api/eslint.config.js
@@ -1,0 +1,19 @@
+import { globalIgnores } from 'eslint/config'
+import pluginVue from 'eslint-plugin-vue'
+import { withVueTs, vueTsConfigs } from '../../../dist/index.mjs'
+
+export default withVueTs(
+  {
+    rootDir: import.meta.dirname,
+  },
+
+  {
+    name: 'app/files-to-lint',
+    files: ['**/*.{ts,mts,tsx,vue}'],
+  },
+
+  globalIgnores(['**/dist/**', '**/coverage/**']),
+
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommendedTypeChecked,
+)

--- a/test/fixtures/with-vue-ts-api/eslint.config.js
+++ b/test/fixtures/with-vue-ts-api/eslint.config.js
@@ -15,5 +15,5 @@ export default withVueTs(
   globalIgnores(['**/dist/**', '**/coverage/**']),
 
   pluginVue.configs['flat/essential'],
-  vueTsConfigs.recommendedTypeChecked,
+  vueTsConfigs.recommended,
 )

--- a/test/fixtures/with-vue-ts-api/package.json
+++ b/test/fixtures/with-vue-ts-api/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "with-vue-ts-api",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "lint": "eslint . --fix"
+  },
+  "dependencies": {
+    "vue": "^3.5.35"
+  },
+  "devDependencies": {
+    "@vue/eslint-config-typescript": "workspace:*",
+    "eslint": "^10.4.0",
+    "eslint-plugin-vue": "~10.9.1",
+    "typescript": "~6.0.0"
+  }
+}

--- a/test/fixtures/with-vue-ts-api/src/App.vue
+++ b/test/fixtures/with-vue-ts-api/src/App.vue
@@ -1,0 +1,7 @@
+<script setup lang="ts">
+const message = 'Hello Vue'
+</script>
+
+<template>
+  <div>{{ message }}</div>
+</template>

--- a/test/fixtures/with-vue-ts-api/src/main.ts
+++ b/test/fixtures/with-vue-ts-api/src/main.ts
@@ -1,0 +1,1 @@
+export const message = 'Hello TypeScript'

--- a/test/fixtures/with-vue-ts-api/tsconfig.json
+++ b/test/fixtures/with-vue-ts-api/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "Preserve",
+    "moduleResolution": "Bundler",
+    "verbatimModuleSyntax": true,
+    "isolatedModules": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue"]
+}

--- a/test/migrate.spec.ts
+++ b/test/migrate.spec.ts
@@ -1,0 +1,241 @@
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, test } from 'vitest'
+import { execa } from 'execa'
+
+import { applyToWithVueTsMigrationText } from '../src/migrations/toWithVueTs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const repoRoot = path.resolve(__dirname, '..')
+const binPath = path.join(repoRoot, 'dist/bin.js')
+
+function copyFixtureToTempDir(fixtureName: string): {
+  tempDir: string
+  restore: () => void
+} {
+  const sourceDir = path.join(__dirname, 'fixtures', fixtureName)
+  const tempDir = fs.mkdtempSync(
+    path.join(os.tmpdir(), `vue-eslint-config-typescript-${fixtureName}-`),
+  )
+
+  fs.cpSync(sourceDir, tempDir, { recursive: true })
+
+  return {
+    tempDir,
+    restore() {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    },
+  }
+}
+
+function runMigrationCli(cwd: string, ...args: string[]) {
+  return execa('node', [binPath, 'migrate-to-with-vue-ts', ...args], {
+    cwd,
+    reject: false,
+  })
+}
+
+describe('withVueTs migration', () => {
+  test('rewrites legacy helper-based JS configs', () => {
+    const filename = path.join(
+      __dirname,
+      'fixtures',
+      'migrate-legacy-js',
+      'eslint.config.js',
+    )
+    const input = fs.readFileSync(filename, 'utf8')
+
+    const result = applyToWithVueTsMigrationText(input, filename)
+
+    expect(result.analysis.status).toBe('fixable')
+    expect(result.changed).toBe(true)
+    expect(result.output).toContain(
+      "import { withVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'",
+    )
+    expect(result.output).toContain('export default withVueTs(')
+    expect(result.output).toContain("scriptLangs: ['ts', 'js']")
+    expect(result.output).toContain('includeDotFolders: true')
+    expect(result.output).not.toContain('defineConfigWithVueTs')
+    expect(result.output).not.toContain('configureVueProject')
+  })
+
+  test('migrate CLI rewrites discovered .ts config files', async () => {
+    const { tempDir, restore } = copyFixtureToTempDir('migrate-legacy-ts')
+
+    try {
+      const { stdout, failed } = await runMigrationCli(tempDir, '--yes')
+
+      expect(failed).toBe(false)
+      expect(stdout).toContain('Auto-migratable:')
+      expect(stdout).toContain('Updated 1 file(s).')
+
+      const migrated = fs.readFileSync(
+        path.join(tempDir, 'eslint.config.ts'),
+        'utf8',
+      )
+
+      expect(migrated).toContain(
+        "import { withVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'",
+      )
+      expect(migrated).toContain('const config = withVueTs(')
+      expect(migrated).toContain('projectOptions')
+      expect(migrated).not.toContain('defineConfigWithVueTs')
+      expect(migrated).not.toContain('configureVueProject')
+    } finally {
+      restore()
+    }
+  })
+
+  test('migrate CLI accepts explicit JS paths', async () => {
+    const { tempDir, restore } = copyFixtureToTempDir('migrate-legacy-js')
+
+    try {
+      const { stdout, failed } = await runMigrationCli(
+        tempDir,
+        'eslint.config.js',
+        '--yes',
+      )
+
+      expect(failed).toBe(false)
+      expect(stdout).toContain('Updated 1 file(s).')
+
+      const migrated = fs.readFileSync(
+        path.join(tempDir, 'eslint.config.js'),
+        'utf8',
+      )
+      expect(migrated).toContain('export default withVueTs(')
+    } finally {
+      restore()
+    }
+  })
+
+  test('migrate CLI accepts the 14.9 versioned alias', async () => {
+    const { tempDir, restore } = copyFixtureToTempDir('migrate-legacy-js')
+
+    try {
+      const { stdout, failed } = await execa(
+        'node',
+        [binPath, 'migrate-14.9', 'eslint.config.js', '--yes'],
+        {
+          cwd: tempDir,
+          reject: false,
+        },
+      )
+
+      expect(failed).toBe(false)
+      expect(stdout).toContain('Updated 1 file(s).')
+
+      const migrated = fs.readFileSync(
+        path.join(tempDir, 'eslint.config.js'),
+        'utf8',
+      )
+      expect(migrated).toContain('export default withVueTs(')
+    } finally {
+      restore()
+    }
+  })
+
+  test('migrate CLI reports unsupported createConfig usage without changing files', async () => {
+    const { tempDir, restore } = copyFixtureToTempDir('migrate-create-config')
+    const filename = path.join(tempDir, 'eslint.config.js')
+    const original = fs.readFileSync(filename, 'utf8')
+
+    try {
+      const { stdout, failed } = await runMigrationCli(tempDir, '--yes')
+
+      expect(failed).toBe(false)
+      expect(stdout).toContain('Needs manual review:')
+      expect(stdout).toContain('createConfig')
+      expect(stdout).not.toContain('Updated 1 file(s).')
+      expect(fs.readFileSync(filename, 'utf8')).toBe(original)
+    } finally {
+      restore()
+    }
+  })
+
+  test('migrate CLI accepts explicit absolute paths outside cwd', async () => {
+    const { tempDir, restore } = copyFixtureToTempDir('migrate-legacy-ts')
+    const filename = path.join(tempDir, 'eslint.config.ts')
+
+    try {
+      const { stdout, failed } = await runMigrationCli(
+        repoRoot,
+        filename,
+        '--yes',
+      )
+
+      expect(failed).toBe(false)
+      expect(stdout).toContain('Auto-migratable:')
+      expect(stdout).toContain('Updated 1 file(s).')
+      expect(fs.readFileSync(filename, 'utf8')).toContain('withVueTs(')
+    } finally {
+      restore()
+    }
+  })
+
+  test('reports unsupported when configureVueProject is not a top-level call', () => {
+    const input = `import pluginVue from 'eslint-plugin-vue'
+import { defineConfigWithVueTs, configureVueProject, vueTsConfigs } from '@vue/eslint-config-typescript'
+
+if (process.env.CI) configureVueProject({ rootDir: import.meta.dirname })
+
+export default defineConfigWithVueTs(
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+)
+`
+
+    const result = applyToWithVueTsMigrationText(input, 'eslint.config.mjs')
+
+    expect(result.analysis.status).toBe('unsupported')
+    if (result.analysis.status === 'unsupported') {
+      expect(result.analysis.reasons).toContain(
+        'Only top-level `configureVueProject(...)` calls are supported by this migration.',
+      )
+    }
+  })
+
+  test('reports unsupported for reassigned exported variables', () => {
+    const input = `import pluginVue from 'eslint-plugin-vue'
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+
+let config = defineConfigWithVueTs(
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+)
+config = []
+export default config
+`
+
+    const result = applyToWithVueTsMigrationText(input, 'eslint.config.mjs')
+
+    expect(result.analysis.status).toBe('unsupported')
+  })
+
+  test('reports unsupported for ambiguous first-argument option objects', () => {
+    const input = `import pluginVue from 'eslint-plugin-vue'
+import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
+
+const shared = { rootDir: import.meta.dirname }
+
+export default defineConfigWithVueTs(
+  { ...shared, rootDir: import.meta.dirname },
+  pluginVue.configs['flat/essential'],
+  vueTsConfigs.recommended,
+)
+`
+
+    const result = applyToWithVueTsMigrationText(input, 'eslint.config.ts')
+
+    expect(result.analysis.status).toBe('unsupported')
+    if (result.analysis.status === 'unsupported') {
+      expect(result.analysis.reasons).toContain(
+        'The first argument to `defineConfigWithVueTs()` could be reinterpreted as `withVueTs()` project options. Please migrate this case manually.',
+      )
+    }
+  })
+})

--- a/test/withVueTs.spec.ts
+++ b/test/withVueTs.spec.ts
@@ -1,0 +1,149 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { defineConfig } from 'eslint/config'
+import { describe, expect, test } from 'vitest'
+import { execa } from 'execa'
+
+import { withVueTs, vueTsConfigs } from '../src'
+
+const WHITESPACE_ONLY = /^\s*$/
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+function runLintAgainst(projectName: string) {
+  const projectDir = path.join(__dirname, './fixtures', projectName)
+  return execa({
+    preferLocal: true,
+    cwd: projectDir,
+    reject: false,
+  })`pnpm --silent lint`
+}
+
+function setupFileMutations(filename: string) {
+  const fileContents = fs.readFileSync(filename, 'utf8')
+
+  function modify(getNewContents: (oldContents: string) => string) {
+    fs.writeFileSync(filename, getNewContents(fileContents))
+  }
+
+  function restore() {
+    fs.writeFileSync(filename, fileContents)
+  }
+
+  return { modify, restore }
+}
+
+describe('withVueTs', () => {
+  test('accepts the options-first form', async () => {
+    const config = await withVueTs(
+      {
+        scriptLangs: ['ts', 'js'],
+      },
+      vueTsConfigs.recommended,
+    )
+
+    const setupConfig = config.find(
+      item => item.name === '@vue/typescript/setup',
+    )
+    expect(setupConfig).toBeDefined()
+
+    const blockLangRule = setupConfig?.rules?.['vue/block-lang']
+    expect(Array.isArray(blockLangRule)).toBe(true)
+
+    const [, options] = blockLangRule as [
+      string,
+      { script: { allowNoLang: boolean } },
+    ]
+    expect(options.script.allowNoLang).toBe(true)
+  })
+
+  test('accepts promised defineConfig output for interop', async () => {
+    const config = await withVueTs(
+      {
+        scriptLangs: ['ts', 'js'],
+      },
+      Promise.resolve(
+        defineConfig({
+          extends: [vueTsConfigs.recommended],
+        }),
+      ),
+    )
+
+    const setupConfig = config.find(
+      item => item.name === '@vue/typescript/setup',
+    )
+    expect(setupConfig).toBeDefined()
+
+    const blockLangRule = setupConfig?.rules?.['vue/block-lang']
+    expect(Array.isArray(blockLangRule)).toBe(true)
+
+    const [, options] = blockLangRule as [
+      string,
+      { script: { allowNoLang: boolean } },
+    ]
+    expect(options.script.allowNoLang).toBe(true)
+  })
+
+  test('treats a promised config in first position as config, not options', async () => {
+    const config = await withVueTs(
+      Promise.resolve(
+        defineConfig({
+          extends: [vueTsConfigs.recommended],
+        }),
+      ),
+    )
+
+    expect(config.some(item => item.name === '@vue/typescript/setup')).toBe(
+      true,
+    )
+  })
+
+  test('works when exported from eslint.config.js', async () => {
+    const { failed, stdout } = await runLintAgainst('with-vue-ts-api')
+    expect(failed).toBe(false)
+    expect(stdout).toMatch(WHITESPACE_ONLY)
+  }, 15000)
+
+  test('still accepts the config-only form', async () => {
+    const config = await withVueTs(vueTsConfigs.recommended)
+
+    expect(config.some(item => item.name === '@vue/typescript/setup')).toBe(
+      true,
+    )
+  })
+
+  test('applies TypeScript rules to .vue files through defineConfig extends', async () => {
+    const appVuePath = path.join(
+      __dirname,
+      './fixtures/with-vue-ts-api/src/App.vue',
+    )
+    const { modify, restore } = setupFileMutations(appVuePath)
+
+    modify(oldContents =>
+      oldContents.replace('</script>', '// @ts-ignore\n</script>'),
+    )
+    const { failed, stdout, stderr } = await runLintAgainst('with-vue-ts-api')
+    restore()
+
+    const output = [stdout, stderr].join('\n')
+    expect(failed).toBe(true)
+    expect(output).toContain('App.vue')
+    expect(output).toContain('@typescript-eslint/ban-ts-comment')
+  }, 15000)
+
+  test('rejects mixed first-argument option/config objects', async () => {
+    const ambiguousFirstArg = {
+      rootDir: __dirname,
+      files: ['**/*.ts'],
+    }
+
+    await expect(
+      withVueTs(ambiguousFirstArg as never, vueTsConfigs.recommended),
+    ).rejects.toThrow(
+      'cannot mix Vue project options with ESLint config keys',
+    )
+  })
+})

--- a/test/withVueTs.spec.ts
+++ b/test/withVueTs.spec.ts
@@ -105,7 +105,7 @@ describe('withVueTs', () => {
     const { failed, stdout } = await runLintAgainst('with-vue-ts-api')
     expect(failed).toBe(false)
     expect(stdout).toMatch(WHITESPACE_ONLY)
-  }, 15000)
+  })
 
   test('still accepts the config-only form', async () => {
     const config = await withVueTs(vueTsConfigs.recommended)
@@ -115,7 +115,29 @@ describe('withVueTs', () => {
     )
   })
 
-  test('applies TypeScript rules to .vue files through defineConfig extends', async () => {
+  test('adds project service configs for type-checked presets', async () => {
+    const config = await withVueTs(
+      {
+        rootDir: path.join(__dirname, './fixtures/with-vue-ts-api'),
+      },
+      vueTsConfigs.recommendedTypeChecked,
+    )
+
+    expect(
+      config.some(
+        item =>
+          item.name === '@vue/typescript/default-project-service-for-ts-files',
+      ),
+    ).toBe(true)
+    expect(
+      config.some(
+        item =>
+          item.name === '@vue/typescript/default-project-service-for-vue-files',
+      ),
+    ).toBe(true)
+  })
+
+  test('applies TypeScript rules to .vue files', async () => {
     const appVuePath = path.join(
       __dirname,
       './fixtures/with-vue-ts-api/src/App.vue',
@@ -132,7 +154,7 @@ describe('withVueTs', () => {
     expect(failed).toBe(true)
     expect(output).toContain('App.vue')
     expect(output).toContain('@typescript-eslint/ban-ts-comment')
-  }, 15000)
+  })
 
   test('rejects mixed first-argument option/config objects', async () => {
     const ambiguousFirstArg = {


### PR DESCRIPTION
This refactor makes `vueTsConfigs.*` compatible with ESLint’s normal flat config shape, while keeping Vue-specific resolution under this package’s control.

Previously, `vueTsConfigs.*` were placeholder objects that only became valid ESLint configs after being passed through `defineConfigWithVueTs(...)`. That made them hard to compose with standard ESLint config helpers and third-party config transformation utilities, because those tools expect ordinary flat config objects.

---

This PR also adds a new `withVueTs(...)` helper built on top of `eslint-flat-config-utils`, which lets it compose with the same flat-config transformation model used by antfu and Nuxt’s ESLint config tooling.

---

With this change:

- `vueTsConfigs.*` now expose tagged flat config objects/arrays compatible with default ESLint config types.
- They can pass through `defineConfig()` from `eslint/config` and other config composition or transformation helpers before final resolution.
- `withVueTs(...)` performs the final Vue-specific resolution step: flattening configs, resolving tagged Vue TypeScript configs, applying `.vue` handling, and inserting the required project-service/type-aware setup.
- `defineConfigWithVueTs(...)` remains supported and now runs through the same transform for backward compatibility.

This gives users a more interoperable API without pretending that `vueTsConfigs.*` are complete standalone configs. A wrapper from this package is still required at the final export boundary so we can correctly adapt TypeScript ESLint presets for Vue SFCs.


A migration command is included for existing projects:

```sh
npx @vue/eslint-config-typescript migrate-to-with-vue-ts
```

The migration command rewrites common legacy configs to this new API. It parses each config with ESLint, records the imports and default export shape, and applies text edits from AST ranges. Unsupported shapes are reported for manual migration.